### PR TITLE
Update max gap size in gap filler job configuration

### DIFF
--- a/jobs/extract_klines_gap_filler.py
+++ b/jobs/extract_klines_gap_filler.py
@@ -665,7 +665,7 @@ Examples:
 
     parser.add_argument("--weekly-chunk-days", type=int, default=7, help="Number of days per weekly chunk (default: 7)")
 
-    parser.add_argument("--max-gap-size-days", type=int, default=30, help="Maximum gap size in days to process (default: 30)")
+    parser.add_argument("--max-gap-size-days", type=int, default=365, help="Maximum gap size in days to process (default: 365)")
 
     parser.add_argument(
         "--db-adapter",

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -60,7 +60,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-days=30
+            - --max-gap-size-days=365
             
             # Environment variables from secrets and configmaps
             env:


### PR DESCRIPTION
- Increased the `--max-gap-size-days` parameter from 30 to 365 in both the Python script and Kubernetes cronjob configuration to allow for extended gap handling.