### PR TITLE
Update max gap size parameter in Kubernetes cronjob configuration

### DIFF
--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -53,7 +53,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-day=700
+            - --max-gap-size-day=3000
             
             env:
             - name: BINANCE_API_KEY
@@ -230,7 +230,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-day=700
+            - --max-gap-size-day=3000
             
             env:
             - name: BINANCE_API_KEY
@@ -407,7 +407,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-day=700
+            - --max-gap-size-day=3000
             
             env:
             - name: BINANCE_API_KEY
@@ -584,7 +584,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-day=700
+            - --max-gap-size-day=3000
             
             env:
             - name: BINANCE_API_KEY
@@ -761,7 +761,7 @@ spec:
             - --max-workers=3
             - --db-adapter=mysql
             - --weekly-chunk-days=7
-            - --max-gap-size-day=700
+            - --max-gap-size-day=3000
             
             env:
             - name: BINANCE_API_KEY


### PR DESCRIPTION
- Increased the `--max-gap-size-day` parameter in the Kubernetes cronjob from 700 to 3000 to allow for greater gap handling capabilities across multiple job configurations.