### PR TITLE
Remove API_KEY and NATS_SUBJECT_PREFIX from Kubernetes cronjob config…

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -151,13 +151,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_PRODUCTION
-            
-            - name: API_KEY
                   
             # Kubernetes environment detection
             - name: K8S_NAMESPACE
@@ -294,15 +287,9 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_PRODUCTION
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
             
             resources:
               requests:
@@ -411,7 +398,6 @@ spec:
                   key: DB_ADAPTER
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
             
             resources:
               requests:
@@ -530,16 +516,10 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_PRODUCTION
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
@@ -718,15 +698,10 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_PRODUCTION
+
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
             
             resources:
               requests:

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -108,8 +108,7 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
@@ -298,8 +297,7 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
@@ -488,8 +486,7 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
@@ -678,8 +675,7 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
@@ -868,8 +864,7 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            - name: API_KEY
-                  
+            
             # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:


### PR DESCRIPTION
…urations to streamline environment variable management and simplify setup.