### PR TITLE
Remove NATS_SUBJECT_PREFIX environment variable references from Kuber…

### DIFF
--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -100,11 +100,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_GAP_FILLER
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
@@ -289,11 +284,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_GAP_FILLER
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
@@ -478,11 +468,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_GAP_FILLER
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
@@ -667,11 +652,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_GAP_FILLER
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
@@ -856,11 +836,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            - name: NATS_SUBJECT_PREFIX
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_SUBJECT_PREFIX_GAP_FILLER
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"


### PR DESCRIPTION
…netes cronjob configurations to streamline variable management and simplify setup.