### PR TITLE
fix: update .cursorrules to reflect remote MicroK8s cluster instead of local

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,12 +1,12 @@
 # Cursor AI Rules for Petrosa Binance Data Extractor
 
 ## Repository Context
-This is a Kubernetes-based cryptocurrency data extraction system using MicroK8s cluster.
+This is a Kubernetes-based cryptocurrency data extraction system using a remote MicroK8s cluster.
 
 ## Key Files to Reference
 - `docs/REPOSITORY_SETUP_GUIDE.md` - Complete setup and troubleshooting guide
 - `docs/QUICK_REFERENCE.md` - Essential commands and common issues
-- `k8s/kubeconfig.yaml` - Local MicroK8s cluster configuration
+- `k8s/kubeconfig.yaml` - Remote MicroK8s cluster configuration
 
 ## Prerequisites & Installation
 - **MicroK8s**: Install with `sudo snap install microk8s --classic` (Linux) or `brew install microk8s` (macOS)
@@ -15,7 +15,7 @@ This is a Kubernetes-based cryptocurrency data extraction system using MicroK8s 
 
 ## Common Issues & Solutions
 When users encounter connection issues:
-1. **AWS SSO errors**: This repo uses local MicroK8s, not AWS EKS
+1. **AWS SSO errors**: This repo uses remote MicroK8s, not AWS EKS
 2. **kubectl connection**: Use `export KUBECONFIG=k8s/kubeconfig.yaml`
 3. **Port forwarding**: Use `kubectl --kubeconfig=k8s/kubeconfig.yaml port-forward`
 4. **Certificate issues**: Add `--insecure-skip-tls-verify` flag
@@ -24,13 +24,13 @@ When users encounter connection issues:
 ## Development Workflow
 1. Install MicroK8s: `sudo snap install microk8s --classic`
 2. Set kubeconfig: `export KUBECONFIG=k8s/kubeconfig.yaml`
-3. Start MicroK8s: `microk8s start`
-4. Deploy locally: `./scripts/deploy-local.sh`
+3. Connect to remote MicroK8s cluster
+4. Deploy to remote cluster: `./scripts/deploy-local.sh`
 5. Port forward services as needed
 
 ## Always Reference
 - Check `docs/REPOSITORY_SETUP_GUIDE.md` for detailed setup instructions
 - Check `docs/QUICK_REFERENCE.md` for common commands and troubleshooting
-- Use `k8s/kubeconfig.yaml` for cluster connection
-- This is a MicroK8s setup, not AWS EKS
+- Use `k8s/kubeconfig.yaml` for remote cluster connection
+- This is a remote MicroK8s setup, not AWS EKS
 - If MicroK8s is not installed, guide users to install it first 


### PR DESCRIPTION
This PR updates the .cursorrules file to correctly reflect that this repository uses a remote MicroK8s cluster rather than a local one. This will help prevent confusion for users setting up the project.