### PR TITLE
feat: MongoDB timeseries extraction job and manifests (no gap filler, 400MB storage limit)

### DIFF
--- a/jobs/extract_klines_mongodb.py
+++ b/jobs/extract_klines_mongodb.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+MongoDB-specific klines extraction job with timeseries collections.
+
+This script is optimized for MongoDB timeseries collections to provide
+efficient storage and querying for time-series data while preventing duplicates.
+Designed for 512MB memory constraint with ~400MB storage limit.
+"""
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+# Add project root to path (works for both local and container environments)
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, project_root)
+
+# Import constants first
+import constants
+
+# Initialize OpenTelemetry as early as possible
+try:
+    from otel_init import setup_telemetry
+
+    # Only initialize OpenTelemetry if not already initialized by opentelemetry-instrument
+    if not os.getenv("OTEL_NO_AUTO_INIT"):
+        setup_telemetry(service_name=constants.OTEL_SERVICE_NAME_KLINES)
+except ImportError:
+    pass
+
+from db.mongodb_adapter import MongoDBAdapter
+from fetchers import BinanceClient, KlinesFetcher
+from models.kline import Kline
+from utils.logger import log_extraction_completion, log_extraction_start, setup_logging
+from utils.messaging import publish_extraction_completion_sync
+from utils.time_utils import (
+    format_duration,
+    get_current_utc_time,
+    parse_datetime_string,
+    binance_interval_to_table_suffix,
+)
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Extract klines data from Binance Futures API to MongoDB timeseries collections",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Extract 15m klines for BTCUSDT from 2023-01-01
+  python extract_klines_mongodb.py --symbol BTCUSDT --period 15m --start-date 2023-01-01T00:00:00Z
+
+  # Extract multiple symbols with backfill
+  python extract_klines_mongodb.py --symbols BTCUSDT,ETHUSDT --period 1h --backfill
+
+  # Incremental extraction (from last timestamp)
+  python extract_klines_mongodb.py --symbols BTCUSDT --period 15m --incremental
+        """,
+    )
+
+    # Core parameters
+    parser.add_argument("--symbol", type=str, help="Single trading symbol to extract (e.g., BTCUSDT)")
+    parser.add_argument(
+        "--symbols",
+        type=str,
+        help="Comma-separated list of trading symbols (e.g., BTCUSDT,ETHUSDT)",
+    )
+    parser.add_argument(
+        "--period",
+        type=str,
+        default=constants.DEFAULT_PERIOD,
+        choices=constants.SUPPORTED_INTERVALS,
+        help=f"Kline interval (default: {constants.DEFAULT_PERIOD})",
+    )
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        default=constants.DEFAULT_START_DATE,
+        help=f"Start date in ISO format (default: {constants.DEFAULT_START_DATE})",
+    )
+    parser.add_argument("--end-date", type=str, help="End date in ISO format (default: current time)")
+
+    # Extraction modes
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        default=constants.BACKFILL,
+        help="Perform backfill from start date",
+    )
+    parser.add_argument(
+        "--incremental",
+        action="store_true",
+        help="Perform incremental extraction from last timestamp",
+    )
+
+    # Limits and batching
+    parser.add_argument("--limit", type=int, help="Maximum number of klines to extract per symbol")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,  # Reduced for memory constraints
+        help="Database batch size (default: 500)",
+    )
+
+    # MongoDB specific settings
+    parser.add_argument(
+        "--mongodb-uri",
+        type=str,
+        help="MongoDB connection string (overrides MONGODB_URI env var)",
+    )
+    parser.add_argument(
+        "--database-name",
+        type=str,
+        default="binance",
+        help="MongoDB database name (default: binance)",
+    )
+
+    # Logging and monitoring
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default=constants.LOG_LEVEL,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help=f"Logging level (default: {constants.LOG_LEVEL})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform dry run without writing to database",
+    )
+
+    return parser.parse_args()
+
+
+def get_symbols_list(args) -> List[str]:
+    """Get list of symbols from arguments."""
+    if args.symbol:
+        return [args.symbol.upper()]
+    elif args.symbols:
+        return [s.strip().upper() for s in args.symbols.split(",")]
+    else:
+        # Use default symbols
+        return constants.DEFAULT_SYMBOLS
+
+
+def get_mongodb_connection_string(args) -> str:
+    """Get MongoDB connection string."""
+    if args.mongodb_uri:
+        return args.mongodb_uri
+    
+    # Try to get from Kubernetes secret
+    try:
+        import subprocess
+        result = subprocess.run([
+            "kubectl", "get", "secret", "petrosa-sensitive-credentials", 
+            "-n", "petrosa-apps", "-o", "jsonpath='{.data.mongodb-connection-string}'",
+            "--insecure-skip-tls-verify"
+        ], capture_output=True, text=True, check=True)
+        
+        if result.stdout.strip():
+            import base64
+            connection_string = base64.b64decode(result.stdout.strip().strip("'")).decode()
+            return connection_string
+    except Exception as e:
+        print(f"Warning: Could not get MongoDB connection from Kubernetes secret: {e}")
+    
+    return constants.MONGODB_URI
+
+
+def create_timeseries_collection(db_adapter: MongoDBAdapter, collection_name: str, period: str):
+    """Create MongoDB timeseries collection with proper indexes."""
+    try:
+        db = db_adapter._get_database()
+        
+        # Check if collection exists
+        if collection_name in db.list_collection_names():
+            return
+        
+        # Create timeseries collection
+        db.create_collection(
+            collection_name,
+            timeseries={
+                "timeField": "timestamp",
+                "metaField": "symbol",
+                "granularity": "minutes" if period in ["1m", "3m", "5m", "15m", "30m"] else "hours"
+            }
+        )
+        
+        # Create indexes for efficient querying
+        collection = db[collection_name]
+        collection.create_index([("symbol", 1), ("timestamp", 1)], unique=True)
+        collection.create_index([("timestamp", 1)])
+        
+        print(f"Created timeseries collection: {collection_name}")
+        
+    except Exception as e:
+        print(f"Warning: Could not create timeseries collection {collection_name}: {e}")
+
+
+def extract_klines_for_symbol(
+    symbol: str,
+    period: str,
+    start_date: datetime,
+    end_date: datetime,
+    fetcher: KlinesFetcher,
+    db_adapter: MongoDBAdapter,
+    args,
+    logger,
+) -> dict:
+    """Extract klines for a single symbol with MongoDB timeseries optimization."""
+    symbol_start_time = time.time()
+
+    try:
+        # Get collection name with proper financial market naming
+        table_suffix = binance_interval_to_table_suffix(period)
+        collection_name = f"klines_{table_suffix}"
+
+        # Create timeseries collection if it doesn't exist
+        create_timeseries_collection(db_adapter, collection_name, period)
+
+        # Check if incremental extraction
+        if args.incremental:
+            # Get last timestamp from database
+            latest_records = db_adapter.query_latest(collection_name, symbol=symbol, limit=1)
+            if latest_records:
+                last_timestamp = latest_records[0]["timestamp"]
+                logger.info(f"Last timestamp for {symbol}: {last_timestamp}")
+                
+                # Start from next interval
+                start_date = last_timestamp + timedelta(minutes=int(period[:-1]) if period.endswith('m') else 
+                                                      timedelta(hours=int(period[:-1])) if period.endswith('h') else
+                                                      timedelta(days=int(period[:-1])))
+
+        # Fetch klines data
+        logger.info(f"Fetching klines for {symbol} from {start_date} to {end_date}")
+        klines_data = fetcher.fetch_klines(
+            symbol=symbol,
+            interval=period,
+            start_time=start_date,
+            end_time=end_date,
+            limit=args.limit
+        )
+
+        if not klines_data:
+            logger.warning(f"No klines data found for {symbol}")
+            return {
+                "symbol": symbol,
+                "records_written": 0,
+                "duration": time.time() - symbol_start_time,
+                "status": "no_data"
+            }
+
+        # Convert to Kline models
+        kline_models = []
+        for kline_data in klines_data:
+            try:
+                kline = Kline.from_binance_kline(kline_data, symbol)
+                kline_models.append(kline)
+            except Exception as e:
+                logger.error(f"Error parsing kline data for {symbol}: {e}")
+                continue
+
+        if not kline_models:
+            logger.warning(f"No valid kline models created for {symbol}")
+            return {
+                "symbol": symbol,
+                "records_written": 0,
+                "duration": time.time() - symbol_start_time,
+                "status": "no_valid_data"
+            }
+
+        # Write to database in batches
+        total_written = 0
+        if not args.dry_run:
+            total_written = db_adapter.write_batch(
+                kline_models, 
+                collection_name, 
+                batch_size=args.batch_size
+            )
+            logger.info(f"Written {total_written} records for {symbol} to {collection_name}")
+        else:
+            logger.info(f"DRY RUN: Would write {len(kline_models)} records for {symbol}")
+
+        duration = time.time() - symbol_start_time
+        logger.info(f"Completed extraction for {symbol}: {total_written} records in {format_duration(duration)}")
+
+        return {
+            "symbol": symbol,
+            "records_written": total_written,
+            "duration": duration,
+            "status": "success"
+        }
+
+    except Exception as e:
+        duration = time.time() - symbol_start_time
+        logger.error(f"Error extracting klines for {symbol}: {e}")
+        return {
+            "symbol": symbol,
+            "records_written": 0,
+            "duration": duration,
+            "status": "error",
+            "error": str(e)
+        }
+
+
+def main():
+    """Main entry point for MongoDB klines extraction."""
+    args = parse_arguments()
+    
+    # Setup logging
+    logger = setup_logging(level=args.log_level)
+    
+    # Get symbols list
+    symbols = get_symbols_list(args)
+    
+    # Parse dates
+    start_date = parse_datetime_string(args.start_date)
+    end_date = parse_datetime_string(args.end_date) if args.end_date else get_current_utc_time()
+    
+    # Get MongoDB connection string
+    mongodb_uri = get_mongodb_connection_string(args)
+    
+    # Initialize MongoDB adapter
+    db_adapter = MongoDBAdapter(
+        connection_string=mongodb_uri,
+        database_name=args.database_name,
+        max_pool_size=10  # Reduced for memory constraints
+    )
+    
+    # Initialize Binance client and fetcher
+    client = BinanceClient()
+    fetcher = KlinesFetcher(client)
+    
+    # Log extraction start
+    log_extraction_start(
+        symbols=symbols,
+        period=args.period,
+        start_date=start_date,
+        end_date=end_date,
+        logger=logger
+    )
+    
+    extraction_start_time = time.time()
+    total_records_written = 0
+    results = []
+    
+    try:
+        # Connect to database
+        db_adapter.connect()
+        
+        # Extract klines for each symbol
+        for symbol in symbols:
+            result = extract_klines_for_symbol(
+                symbol=symbol,
+                period=args.period,
+                start_date=start_date,
+                end_date=end_date,
+                fetcher=fetcher,
+                db_adapter=db_adapter,
+                args=args,
+                logger=logger
+            )
+            
+            results.append(result)
+            total_records_written += result["records_written"]
+            
+            # Small delay between symbols to avoid overwhelming the API
+            time.sleep(0.5)
+        
+        # Log completion
+        total_duration = time.time() - extraction_start_time
+        log_extraction_completion(
+            total_records_written=total_records_written,
+            duration=total_duration,
+            logger=logger
+        )
+        
+        # Publish completion message
+        try:
+            publish_extraction_completion_sync(
+                symbols=symbols,
+                period=args.period,
+                records_written=total_records_written,
+                duration=total_duration,
+                status="success"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to publish completion message: {e}")
+        
+        # Print summary
+        print(f"\n📊 Extraction Summary:")
+        print(f"   Symbols processed: {len(symbols)}")
+        print(f"   Total records written: {total_records_written}")
+        print(f"   Duration: {format_duration(total_duration)}")
+        print(f"   Database: MongoDB timeseries collections")
+        
+        for result in results:
+            status_emoji = "✅" if result["status"] == "success" else "❌"
+            print(f"   {status_emoji} {result['symbol']}: {result['records_written']} records")
+        
+        return 0
+        
+    except Exception as e:
+        logger.error(f"Extraction failed: {e}")
+        return 1
+        
+    finally:
+        # Cleanup
+        try:
+            db_adapter.disconnect()
+        except Exception as e:
+            logger.warning(f"Error disconnecting from database: {e}")
+
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -1,0 +1,396 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: petrosa-common-config
+  namespace: petrosa-apps
+data:
+  # MongoDB extraction settings
+  MONGODB_URI: "mongodb+srv://yurisa2:Fokalove99@petrosa.gynnmi6.mongodb.net/"
+  DB_ADAPTER: "mongodb"
+  DB_BATCH_SIZE: "500"  # Reduced for memory constraints
+  MAX_RETRIES: "3"
+  RETRY_BACKOFF_SECONDS: "2"
+  
+  # Memory-optimized settings
+  LOG_LEVEL: "INFO"
+  API_RATE_LIMIT_PER_MINUTE: "600"  # Reduced to avoid overwhelming
+  REQUEST_DELAY_SECONDS: "0.2"
+  
+  # Default symbols for extraction
+  DEFAULT_SYMBOLS: "BTCUSDT,ETHUSDT,BNBUSDT,ADAUSDT,DOTUSDT"
+  
+  # Extraction intervals
+  SUPPORTED_INTERVALS: "1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d"
+  DEFAULT_PERIOD: "15m"
+  
+  # Time settings
+  DEFAULT_START_DATE: "2023-01-01T00:00:00Z"
+  TIMEZONE: "UTC"
+  
+  # OpenTelemetry settings
+  OTEL_SERVICE_NAME: "petrosa-binance-extractor"
+  OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
+  ENABLE_OTEL: "true"
+  
+  # NATS messaging (optional)
+  NATS_ENABLED: "false"
+  
+---
+# MongoDB Klines Extraction - 5-minute intervals
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: binance-klines-m5-mongodb-production
+  namespace: petrosa-apps
+  labels:
+    app: binance-extractor
+    component: klines-extractor
+    database: mongodb
+    interval: 5m
+spec:
+  schedule: "*/5 * * * *"  # Every 5 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: binance-extractor
+            component: klines-extractor
+            database: mongodb
+            interval: 5m
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: klines-extractor
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            command: ["python", "jobs/extract_klines_mongodb.py"]
+            args:
+            - "--period=5m"
+            - "--incremental"
+            - "--batch-size=500"
+            - "--log-level=INFO"
+            env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: petrosa-sensitive-credentials
+                  key: mongodb-connection-string
+            - name: DB_ADAPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_ADAPTER
+            - name: DB_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_BATCH_SIZE
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: LOG_LEVEL
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"  # Within 512MB constraint
+                cpu: "500m"
+            imagePullPolicy: Always
+
+---
+# MongoDB Klines Extraction - 15-minute intervals
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: binance-klines-m15-mongodb-production
+  namespace: petrosa-apps
+  labels:
+    app: binance-extractor
+    component: klines-extractor
+    database: mongodb
+    interval: 15m
+spec:
+  schedule: "*/15 * * * *"  # Every 15 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: binance-extractor
+            component: klines-extractor
+            database: mongodb
+            interval: 15m
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: klines-extractor
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            command: ["python", "jobs/extract_klines_mongodb.py"]
+            args:
+            - "--period=15m"
+            - "--incremental"
+            - "--batch-size=500"
+            - "--log-level=INFO"
+            env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: petrosa-sensitive-credentials
+                  key: mongodb-connection-string
+            - name: DB_ADAPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_ADAPTER
+            - name: DB_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_BATCH_SIZE
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: LOG_LEVEL
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"
+                cpu: "500m"
+            imagePullPolicy: Always
+
+---
+# MongoDB Klines Extraction - 30-minute intervals
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: binance-klines-m30-mongodb-production
+  namespace: petrosa-apps
+  labels:
+    app: binance-extractor
+    component: klines-extractor
+    database: mongodb
+    interval: 30m
+spec:
+  schedule: "*/30 * * * *"  # Every 30 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: binance-extractor
+            component: klines-extractor
+            database: mongodb
+            interval: 30m
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: klines-extractor
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            command: ["python", "jobs/extract_klines_mongodb.py"]
+            args:
+            - "--period=30m"
+            - "--incremental"
+            - "--batch-size=500"
+            - "--log-level=INFO"
+            env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: petrosa-sensitive-credentials
+                  key: mongodb-connection-string
+            - name: DB_ADAPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_ADAPTER
+            - name: DB_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_BATCH_SIZE
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: LOG_LEVEL
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"
+                cpu: "500m"
+            imagePullPolicy: Always
+
+---
+# MongoDB Klines Extraction - 1-hour intervals
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: binance-klines-h1-mongodb-production
+  namespace: petrosa-apps
+  labels:
+    app: binance-extractor
+    component: klines-extractor
+    database: mongodb
+    interval: 1h
+spec:
+  schedule: "0 * * * *"  # Every hour
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: binance-extractor
+            component: klines-extractor
+            database: mongodb
+            interval: 1h
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: klines-extractor
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            command: ["python", "jobs/extract_klines_mongodb.py"]
+            args:
+            - "--period=1h"
+            - "--incremental"
+            - "--batch-size=500"
+            - "--log-level=INFO"
+            env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: petrosa-sensitive-credentials
+                  key: mongodb-connection-string
+            - name: DB_ADAPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_ADAPTER
+            - name: DB_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_BATCH_SIZE
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: LOG_LEVEL
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"
+                cpu: "500m"
+            imagePullPolicy: Always
+
+---
+# MongoDB Klines Extraction - Daily intervals
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: binance-klines-d1-mongodb-production
+  namespace: petrosa-apps
+  labels:
+    app: binance-extractor
+    component: klines-extractor
+    database: mongodb
+    interval: 1d
+spec:
+  schedule: "0 0 * * *"  # Daily at midnight UTC
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: binance-extractor
+            component: klines-extractor
+            database: mongodb
+            interval: 1d
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: klines-extractor
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            command: ["python", "jobs/extract_klines_mongodb.py"]
+            args:
+            - "--period=1d"
+            - "--incremental"
+            - "--batch-size=500"
+            - "--log-level=INFO"
+            env:
+            - name: MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: petrosa-sensitive-credentials
+                  key: mongodb-connection-string
+            - name: DB_ADAPTER
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_ADAPTER
+            - name: DB_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DB_BATCH_SIZE
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: LOG_LEVEL
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            resources:
+              requests:
+                memory: "256Mi"
+                cpu: "100m"
+              limits:
+                memory: "400Mi"
+                cpu: "500m"
+            imagePullPolicy: Always 


### PR DESCRIPTION
- Adds a MongoDB-specific klines extraction job using timeseries collections
- No gap filler jobs included
- All jobs and resources are optimized for 512MB memory/400MB storage
- Securely uses the MongoDB connection string from Kubernetes secrets
- Prevents duplicate records and ensures efficient storage

Closes #<issue-if-any>