### PR TITLE
fix: correct error classifier test expectations for socket timeout

### DIFF
--- a/tests/test_error_classifier.py
+++ b/tests/test_error_classifier.py
@@ -41,7 +41,6 @@ class TestErrorClassification:
             Exception("MongoDB connection pool exhausted"),  # Updated to be MongoDB-specific
             Exception("Server selection timeout"),
             Exception("Network timeout"),
-            Exception("Socket timeout"),
             Exception("Read timeout"),
             Exception("Write timeout"),
         ]
@@ -137,7 +136,7 @@ class TestErrorClassification:
             Exception("TLS handshake"),
             Exception("Connection aborted"),
             Exception("Connection reset"),
-            Exception("Socket timeout"),
+            Exception("Socket timeout"),  # This should be NETWORK_ERROR
             Exception("Network unreachable"),
         ]
         


### PR DESCRIPTION
## Summary

Fixes GitHub Actions pipeline failure by correcting test expectations in the error classifier.

## Problem
- Test  was failing because it expected 'Socket timeout' to be classified as 
- The error classifier correctly classifies 'Socket timeout' as  (which is more accurate)
- This was causing the CI/CD pipeline to fail

## Solution
- Removed 'Socket timeout' from the MongoDB connection errors test
- Socket timeout is correctly classified as  by the error classifier logic
- All tests now pass (221 passed, 0 failed)

## Testing
- ✅ All tests pass locally
- ✅ Error classifier logic remains correct
- ✅ Network errors test still validates 'Socket timeout' as 

## Impact
- Restores GitHub Actions pipeline functionality
- Maintains correct error classification logic
- No functional changes to the error handling system