### PR TITLE
fix: Exclude virtual environment from linting in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,8 +48,8 @@ jobs:
     
     - name: Run linting
       run: |
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=venv/*,.venv/*,htmlcov/*
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=venv/*,.venv/*,htmlcov/*
     
     - name: Run type checking
       run: |


### PR DESCRIPTION
## Summary

This PR fixes the CI/CD pipeline linting failures by excluding virtual environment directories from flake8 checks.

## Problem

The pipeline was failing on the  job because flake8 was checking all files including virtual environment packages, which have many linting issues that are not relevant to our project.

## Solution

- Added  to both flake8 commands in the CI/CD workflow
- This ensures only project source code is checked for linting issues
- Prevents pipeline failures due to virtual environment package issues

## Changes

- Updated  linting commands to exclude virtual environment directories
- Added exclusions for , , and  patterns

## Testing

The fix ensures that:
1. ✅ Project source code is still linted properly
2. ✅ Virtual environment packages are excluded from linting
3. ✅ Pipeline will pass without false positives from dependencies

This should resolve the recent pipeline failures and allow the OpenTelemetry instrumentation changes to deploy successfully.