### PR TITLE
fix: Add flake8 configuration and fix critical linting errors in jobs/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 127
+exclude = venv/*,.venv/*,htmlcov/*
+ignore = E402
+max-complexity = 10 

--- a/jobs/extract_klines_gap_filler.py
+++ b/jobs/extract_klines_gap_filler.py
@@ -31,7 +31,6 @@ except ImportError:
 from db import get_adapter
 from fetchers import BinanceClient, KlinesFetcher
 from models.base import BaseModel
-from models.kline import KlineModel
 from utils.logger import (
     get_logger,
     log_extraction_completion,
@@ -666,7 +665,9 @@ Examples:
     parser.add_argument(
         "--period",
         type=str,
-        choices=["1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d", "3d", "1w", "1M"],
+        choices=[
+            "1m", "3m", "5m", "15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d", "3d", "1w", "1M"
+        ],
         default=constants.DEFAULT_PERIOD,
         help="Kline interval (default: 15m)",
     )


### PR DESCRIPTION
This PR adds a flake8 configuration file and fixes critical linting errors in the jobs/ directory.

## Changes

### Added
-  configuration file with:
  -  to handle imports after sys.path.insert (necessary for project structure)
  -  
  -  to exclude virtual environment directories
  - 

### Fixed in jobs/ directory
- **F401**: Removed unused imports (, , )
- **E501**: Fixed line length issues in 
- **W291/W293**: Fixed whitespace issues in 

### Impact
- Resolves CI/CD pipeline failures due to linting errors
- Maintains code quality while allowing necessary project structure
- Excludes virtual environment from linting checks