### PR TITLE
fix: Add missing import 'Any' in circuit_breaker.py

### DIFF
--- a/utils/circuit_breaker.py
+++ b/utils/circuit_breaker.py
@@ -8,7 +8,7 @@ when database operations are experiencing issues.
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR fixes the F821 undefined name error by adding the missing import for 'Any' in utils/circuit_breaker.py.

## Issue
- F821 undefined name 'Any' error was causing the CI/CD pipeline to fail
- The type annotation was using 'Any' but it wasn't imported

## Fix
- Added 'Any' to the typing imports in utils/circuit_breaker.py
- This should resolve the final critical linting error causing pipeline failures