### PR TITLE
Fix test import issues by adding conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""
+Pytest configuration for the petrosa-binance-data-extractor project.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root)) 


### PR DESCRIPTION
## Problem
The CI pipeline was failing with ModuleNotFoundError for 'utils' module in tests.

## Solution
Added  to set up the Python path correctly for test imports.

## Changes
- Created  with proper Python path setup
- This allows tests to import modules from the project root (utils, db, config, etc.)

## Testing
This should fix the import errors in:
- 
- 
- And all other test files that import from project modules

The conftest.py file adds the project root to sys.path, which is the standard pytest way to handle imports in test environments.