### PR TITLE
fix: remove comments from env sections in klines-all-timeframes-cronjobs.yaml

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -63,7 +63,6 @@ spec:
             - --db-adapter=mysql
             
             env:
-            # Binance API credentials
             - name: BINANCE_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -79,7 +78,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            # Database configuration from ConfigMap
             - name: DB_ADAPTER
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
Removes all comments from env sections in klines-all-timeframes-cronjobs.yaml to resolve YAML parsing errors that were breaking deployment. This should allow kubectl to apply the manifest without error.