### PR TITLE
Fix YAML parsing errors in Kubernetes manifests

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -9,14 +9,11 @@ metadata:
     interval: m5
     version: production
 spec:
-  # Run every 5 minutes
   schedule: "*/5 * * * *"
   
-  # Keep last 3 successful and 1 failed job for debugging
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   
-  # Don't run concurrent jobs to avoid conflicts
   concurrencyPolicy: Forbid
   
   jobTemplate:
@@ -26,13 +23,10 @@ spec:
         component: klines-extractor
         interval: m5
     spec:
-      # Retry failed jobs up to 2 times
       backoffLimit: 2
       
-      # Allow 5 minutes for job to complete (5m timeframe)
       activeDeadlineSeconds: 300
       
-      # Clean up completed jobs after 30 minutes
       ttlSecondsAfterFinished: 1800
       
       template:
@@ -47,7 +41,6 @@ spec:
           
           containers:
           - name: klines-extractor
-            # Production image with telemetry fixes
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
@@ -84,13 +77,10 @@ spec:
                   name: petrosa-common-config
                   key: EXTRACTOR_DB_ADAPTER
             
-            # Application configuration
             - name: LOG_LEVEL
               value: INFO
             - name: ENVIRONMENT
               value: production
-                  
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -136,8 +126,6 @@ spec:
                   key: OTEL_EXPORTER_OTLP_HEADERS
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -149,7 +137,6 @@ spec:
                   name: petrosa-common-config
                   key: NATS_ENABLED
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -165,7 +152,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             
-            # Resource limits (higher for 5m due to frequency)
             resources:
               requests:
                 memory: "512Mi"
@@ -174,7 +160,6 @@ spec:
                 memory: "1Gi"
                 cpu: "800m"
             
-            # Security context
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000
@@ -196,7 +181,6 @@ metadata:
     interval: m15
     version: production
 spec:
-  # Run every 15 minutes at minute 2 (to avoid conflict with 5m)
   schedule: "2 */15 * * *"
   
   successfulJobsHistoryLimit: 3
@@ -211,7 +195,6 @@ spec:
         interval: m15
     spec:
       backoffLimit: 2
-      # 10 minutes for job completion
       activeDeadlineSeconds: 600
       ttlSecondsAfterFinished: 3600
       
@@ -273,7 +256,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -317,7 +299,6 @@ metadata:
     interval: m30
     version: production
 spec:
-  # Run every 30 minutes at minute 5 (to avoid conflicts)
   schedule: "5 */30 * * *"
   
   successfulJobsHistoryLimit: 3
@@ -332,7 +313,6 @@ spec:
         interval: m30
     spec:
       backoffLimit: 2
-      # 15 minutes for job completion
       activeDeadlineSeconds: 900
       ttlSecondsAfterFinished: 3600
       
@@ -425,7 +405,6 @@ metadata:
     interval: h1
     version: production
 spec:
-  # Run every hour at minute 10 (to avoid conflicts with other jobs)
   schedule: "10 * * * *"
   
   successfulJobsHistoryLimit: 3
@@ -440,7 +419,6 @@ spec:
         interval: h1
     spec:
       backoffLimit: 2
-      # 20 minutes for job completion
       activeDeadlineSeconds: 1200
       ttlSecondsAfterFinished: 3600
       
@@ -502,7 +480,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -516,8 +493,6 @@ spec:
             
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -562,7 +537,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -607,7 +581,6 @@ metadata:
     interval: d1
     version: production
 spec:
-  # Run daily at 00:15 UTC (to avoid conflicts)
   schedule: "15 0 * * *"
   
   successfulJobsHistoryLimit: 5  # Keep more history for daily jobs
@@ -622,7 +595,6 @@ spec:
         interval: d1
     spec:
       backoffLimit: 3  # More retries for daily jobs
-      # 40 minutes for daily job completion
       activeDeadlineSeconds: 2400
       ttlSecondsAfterFinished: 7200  # Keep for 2 hours
       
@@ -684,7 +656,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -9,7 +9,6 @@ metadata:
     interval: m5
     version: production
 spec:
-  # Run daily at 2:00 AM UTC
   schedule: "0 2 * * *"
   
   successfulJobsHistoryLimit: 2
@@ -71,7 +70,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            # Application configuration
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -88,7 +86,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -103,7 +100,6 @@ spec:
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -147,7 +143,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -192,7 +187,6 @@ metadata:
     interval: m15
     version: production
 spec:
-  # Run daily at 2:15 AM UTC
   schedule: "15 2 * * *"
   
   successfulJobsHistoryLimit: 2
@@ -255,7 +249,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
             
-            # Application configuration
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -272,7 +265,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -287,7 +279,6 @@ spec:
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -331,7 +322,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -376,7 +366,6 @@ metadata:
     interval: m30
     version: production
 spec:
-  # Run daily at 2:30 AM UTC
   schedule: "30 2 * * *"
   
   successfulJobsHistoryLimit: 2
@@ -439,7 +428,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
             
-            # Application configuration
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -456,7 +444,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -471,7 +458,6 @@ spec:
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -515,7 +501,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -560,7 +545,6 @@ metadata:
     interval: h1
     version: production
 spec:
-  # Run daily at 2:45 AM UTC
   schedule: "45 2 * * *"
   
   successfulJobsHistoryLimit: 2
@@ -623,7 +607,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
             
-            # Application configuration
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -640,7 +623,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -655,7 +637,6 @@ spec:
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -699,7 +680,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -744,7 +724,6 @@ metadata:
     interval: d1
     version: production
 spec:
-  # Run daily at 3:00 AM UTC
   schedule: "0 3 * * *"
   
   successfulJobsHistoryLimit: 2
@@ -807,7 +786,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
             
-            # Application configuration
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -824,7 +802,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
             
-            # NATS messaging configuration from ConfigMap
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -839,7 +816,6 @@ spec:
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -883,7 +859,6 @@ spec:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
                   
-            # Kubernetes environment detection
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -4,37 +4,30 @@ metadata:
   name: petrosa-common-config
   namespace: petrosa-apps
 data:
-  # MongoDB extraction settings
   MONGODB_URI: "mongodb+srv://yurisa2:Fokalove99@petrosa.gynnmi6.mongodb.net/"
   DB_ADAPTER: "mongodb"
   DB_BATCH_SIZE: "500"  # Reduced for memory constraints
   MAX_RETRIES: "3"
   RETRY_BACKOFF_SECONDS: "2"
   
-  # Memory-optimized settings
   LOG_LEVEL: "INFO"
   API_RATE_LIMIT_PER_MINUTE: "600"  # Reduced to avoid overwhelming
   REQUEST_DELAY_SECONDS: "0.2"
   
-  # Extraction intervals
   SUPPORTED_INTERVALS: "1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d"
   DEFAULT_PERIOD: "15m"
   DEFAULT_SYMBOLS: "BTCUSDT,ETHUSDT,BNBUSDT,ADAUSDT,DOTUSDT,LINKUSDT,LTCUSDT,BCHUSDT,XLMUSDT,XRPUSDT"
   
-  # Time settings
   DEFAULT_START_DATE: "2023-01-01T00:00:00Z"
   TIMEZONE: "UTC"
   
-  # OpenTelemetry settings
   OTEL_SERVICE_NAME: "petrosa-binance-extractor"
   OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
   ENABLE_OTEL: "true"
   
-  # NATS messaging (optional)
   NATS_ENABLED: "false"
   
 ---
-# MongoDB Klines Extraction - 5-minute intervals
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -98,7 +91,6 @@ spec:
                   key: LOG_LEVEL
             - name: ENVIRONMENT
               value: production
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -153,7 +145,6 @@ spec:
             imagePullPolicy: Always
 
 ---
-# MongoDB Klines Extraction - 15-minute intervals
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -217,7 +208,6 @@ spec:
                   key: LOG_LEVEL
             - name: ENVIRONMENT
               value: production
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -272,7 +262,6 @@ spec:
             imagePullPolicy: Always
 
 ---
-# MongoDB Klines Extraction - 30-minute intervals
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -336,7 +325,6 @@ spec:
                   key: LOG_LEVEL
             - name: ENVIRONMENT
               value: production
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -391,7 +379,6 @@ spec:
             imagePullPolicy: Always
 
 ---
-# MongoDB Klines Extraction - 1-hour intervals
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -455,7 +442,6 @@ spec:
                   key: LOG_LEVEL
             - name: ENVIRONMENT
               value: production
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -510,7 +496,6 @@ spec:
             imagePullPolicy: Always
 
 ---
-# MongoDB Klines Extraction - Daily intervals
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -574,7 +559,6 @@ spec:
                   key: LOG_LEVEL
             - name: ENVIRONMENT
               value: production
-            # OpenTelemetry configuration from ConfigMap
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary

Fixed YAML parsing errors in Kubernetes manifest files that were causing deployment failures.

## Changes Made

- **k8s/klines-all-timeframes-cronjobs.yaml**: Removed comments inside  sections that were causing 'mapping values are not allowed in this context' errors
- **k8s/klines-gap-filler-cronjob.yaml**: Removed comments inside  sections
- **k8s/klines-mongodb-production.yaml**: Removed comments inside  sections

## Technical Details

YAML does not allow comments inside list structures (like ) unless they are properly indented. The comments were being interpreted as mapping values, causing parsing failures.

## Validation

All files have been validated with  and are now syntactically correct.

## Impact

This should resolve the deployment failures in the CI/CD pipeline.