### PR TITLE
fix: remove blank lines in environment variable sections of Kubernete…

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -76,7 +76,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: EXTRACTOR_DB_ADAPTER
-            
             - name: LOG_LEVEL
               value: INFO
             - name: ENVIRONMENT
@@ -135,7 +134,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -253,7 +251,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -264,7 +261,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             
@@ -475,7 +471,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -486,7 +481,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             - name: ENABLE_OTEL
@@ -531,7 +525,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -649,7 +642,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -660,7 +652,6 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
             

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -85,7 +85,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -96,10 +95,8 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -142,7 +139,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -247,7 +243,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -263,7 +258,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -274,10 +268,8 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -320,7 +312,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -425,7 +416,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -441,7 +431,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -452,10 +441,8 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -498,7 +485,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -603,7 +589,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -619,7 +604,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -630,10 +614,8 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -676,7 +658,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -781,7 +762,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: MYSQL_URI
-            
             - name: LOG_LEVEL
               valueFrom:
                 secretKeyRef:
@@ -797,7 +777,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: DB_ADAPTER
-            
             - name: NATS_URL
               valueFrom:
                 configMapKeyRef:
@@ -808,10 +787,8 @@ spec:
                 configMapKeyRef:
                   name: petrosa-common-config
                   key: NATS_ENABLED
-            
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             - name: ENABLE_OTEL
               valueFrom:
                 configMapKeyRef:
@@ -854,7 +831,6 @@ spec:
                 secretKeyRef:
                   name: petrosa-sensitive-credentials
                   key: OTEL_EXPORTER_OTLP_HEADERS
-                  
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,24 +10,23 @@ data:
   DB_BATCH_SIZE: "500"  # Reduced for memory constraints
   MAX_RETRIES: "3"
   RETRY_BACKOFF_SECONDS: "2"
-  
+
   LOG_LEVEL: "INFO"
   API_RATE_LIMIT_PER_MINUTE: "600"  # Reduced to avoid overwhelming
   REQUEST_DELAY_SECONDS: "0.2"
-  
+
   SUPPORTED_INTERVALS: "1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d"
   DEFAULT_PERIOD: "15m"
   DEFAULT_SYMBOLS: "BTCUSDT,ETHUSDT,BNBUSDT,ADAUSDT,DOTUSDT,LINKUSDT,LTCUSDT,BCHUSDT,XLMUSDT,XRPUSDT"
-  
+
   DEFAULT_START_DATE: "2023-01-01T00:00:00Z"
   TIMEZONE: "UTC"
-  
+
   OTEL_SERVICE_NAME: "petrosa-binance-extractor"
   OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
   ENABLE_OTEL: "true"
-  
+
   NATS_ENABLED: "false"
-  
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
…s manifests to ensure proper YAML parsing

- Eliminated unnecessary blank lines in klines-all-timeframes-cronjobs.yaml, klines-gap-filler-cronjob.yaml, and klines-mongodb-production.yaml
- This change addresses potential YAML parsing errors and improves overall manifest clarity