### PR TITLE
chore: remove deprecated CI/CD workflow file

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,2 +1,0 @@
-# DEPRECATED: This workflow has been split into ci-checks.yml (for PR checks) and deploy.yml (for main branch deploys).
-# Please use those workflows instead. This file is kept for reference only and will be removed in the future.


### PR DESCRIPTION
- Deleted the ci-cd.yml file as it has been deprecated in favor of ci-checks.yml and deploy.yml.
- This change helps streamline the CI/CD process and reduces confusion regarding workflow usage.