### PR TITLE
fix: remove unnecessary blank lines in Kubernetes manifest files

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -24,11 +24,8 @@ spec:
         interval: m5
     spec:
       backoffLimit: 2
-      
       activeDeadlineSeconds: 300
-      
       ttlSecondsAfterFinished: 1800
-      
       template:
         metadata:
           labels:

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -25,7 +25,6 @@ spec:
       backoffLimit: 1
       activeDeadlineSeconds: 21600
       ttlSecondsAfterFinished: 86400
-      
       template:
         metadata:
           labels:
@@ -35,7 +34,6 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-gap-filler
             image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -21,11 +21,9 @@ data:
 
   DEFAULT_START_DATE: "2023-01-01T00:00:00Z"
   TIMEZONE: "UTC"
-
   OTEL_SERVICE_NAME: "petrosa-binance-extractor"
   OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
   ENABLE_OTEL: "true"
-
   NATS_ENABLED: "false"
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
- Eliminated extra blank lines in klines-all-timeframes-cronjobs.yaml, klines-gap-filler-cronjob.yaml, and klines-mongodb-production.yaml to enhance YAML parsing and clarity.
- This change ensures proper formatting and reduces the risk of potential parsing errors during deployments.