### PR TITLE
fix: update image references in Kubernetes manifests to use a specifi…

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -38,7 +38,7 @@ spec:
           
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -203,7 +203,7 @@ spec:
           
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             
             command:
@@ -318,7 +318,7 @@ spec:
           
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             
             command:
@@ -423,7 +423,7 @@ spec:
           
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -594,7 +594,7 @@ spec:
           
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             
             command:

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -209,7 +209,7 @@ spec:
           
           containers:
           - name: klines-gap-filler
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -382,7 +382,7 @@ spec:
           
           containers:
           - name: klines-gap-filler
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -555,7 +555,7 @@ spec:
           
           containers:
           - name: klines-gap-filler
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:
@@ -728,7 +728,7 @@ spec:
           
           containers:
           - name: klines-gap-filler
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             
             command:

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -56,7 +56,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             command:
             - opentelemetry-instrument
             - python
@@ -172,7 +172,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             command:
             - opentelemetry-instrument
             - python
@@ -288,7 +288,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             command:
             - opentelemetry-instrument
             - python
@@ -404,7 +404,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             command:
             - opentelemetry-instrument
             - python
@@ -520,7 +520,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: klines-extractor
-            image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             command:
             - opentelemetry-instrument
             - python


### PR DESCRIPTION
…c Docker Hub image

- Changed image references in klines-all-timeframes-cronjobs.yaml, klines-gap-filler-cronjob.yaml, and klines-mongodb-production.yaml to use the specific Docker Hub image 'yurisa2/petrosa-binance-extractor' instead of the secret placeholder.
- This update ensures that the correct image is pulled during deployments, enhancing reliability.