### PR TITLE
Fix: Proper YAML indentation and formatting for all-timeframes, gap-filler, and mongodb cronjobs

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -10,12 +10,9 @@ metadata:
     version: production
 spec:
   schedule: "*/5 * * * *"
-  
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
-  
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -35,23 +32,19 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-extractor
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
-            
             command:
             - opentelemetry-instrument
             - python
             - -m
             - jobs.extract_klines_production
-            
             args:
             - --period=5m
             - --max-workers=15
             - --db-adapter=mysql
-            
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -145,7 +138,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            
             resources:
               requests:
                 memory: "512Mi"
@@ -153,7 +145,6 @@ spec:
               limits:
                 memory: "1Gi"
                 cpu: "800m"
-            
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000
@@ -175,11 +166,9 @@ metadata:
     version: production
 spec:
   schedule: "2 */15 * * *"
-  
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -190,7 +179,6 @@ spec:
       backoffLimit: 2
       activeDeadlineSeconds: 600
       ttlSecondsAfterFinished: 3600
-      
       template:
         metadata:
           labels:
@@ -200,23 +188,19 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-extractor
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
-            
             command:
             - opentelemetry-instrument
             - python
             - -m
             - jobs.extract_klines_production
-            
             args:
             - --period=15m
             - --max-workers=12
             - --db-adapter=mysql
-            
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -260,7 +244,6 @@ spec:
                   key: NATS_ENABLED
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             resources:
               requests:
                 memory: "384Mi"
@@ -268,7 +251,6 @@ spec:
               limits:
                 memory: "768Mi"
                 cpu: "600m"
-            
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000
@@ -290,11 +272,9 @@ metadata:
     version: production
 spec:
   schedule: "5 */30 * * *"
-  
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -305,7 +285,6 @@ spec:
       backoffLimit: 2
       activeDeadlineSeconds: 900
       ttlSecondsAfterFinished: 3600
-      
       template:
         metadata:
           labels:
@@ -315,23 +294,19 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-extractor
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
-            
             command:
             - opentelemetry-instrument
             - python
             - -m
             - jobs.extract_klines_production
-            
             args:
             - --period=30m
             - --max-workers=10
             - --db-adapter=mysql
-            
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -365,7 +340,6 @@ spec:
                   key: DB_ADAPTER
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             resources:
               requests:
                 memory: "256Mi"
@@ -373,7 +347,6 @@ spec:
               limits:
                 memory: "512Mi"
                 cpu: "500m"
-            
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000
@@ -395,11 +368,9 @@ metadata:
     version: production
 spec:
   schedule: "10 * * * *"
-  
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -410,7 +381,6 @@ spec:
       backoffLimit: 2
       activeDeadlineSeconds: 1200
       ttlSecondsAfterFinished: 3600
-      
       template:
         metadata:
           labels:
@@ -420,23 +390,19 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-extractor
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
-            
             command:
             - opentelemetry-instrument
             - python
             - -m
             - jobs.extract_klines_production
-            
             args:
             - --period=1h
             - --max-workers=8
             - --db-adapter=mysql
-            
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -536,7 +502,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            
             resources:
               requests:
                 memory: "256Mi"
@@ -544,7 +509,6 @@ spec:
               limits:
                 memory: "512Mi"
                 cpu: "500m"
-            
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000
@@ -566,11 +530,9 @@ metadata:
     version: production
 spec:
   schedule: "15 0 * * *"
-  
   successfulJobsHistoryLimit: 5  # Keep more history for daily jobs
   failedJobsHistoryLimit: 2
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -581,7 +543,6 @@ spec:
       backoffLimit: 3  # More retries for daily jobs
       activeDeadlineSeconds: 2400
       ttlSecondsAfterFinished: 7200  # Keep for 2 hours
-      
       template:
         metadata:
           labels:
@@ -591,23 +552,19 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
           - name: klines-extractor
             image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
-            
             command:
             - opentelemetry-instrument
             - python
             - -m
             - jobs.extract_klines_production
-            
             args:
             - --period=1d
             - --max-workers=6
             - --db-adapter=mysql
-            
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -651,7 +608,6 @@ spec:
                   key: NATS_ENABLED
             - name: OTEL_NO_AUTO_INIT
               value: "1"
-            
             resources:
               requests:
                 memory: "256Mi"
@@ -659,7 +615,6 @@ spec:
               limits:
                 memory: "512Mi"
                 cpu: "500m"
-            
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000

--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -33,126 +34,126 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - --period=5m
-            - --max-workers=15
-            - --db-adapter=mysql
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: EXTRACTOR_DB_ADAPTER
-            - name: LOG_LEVEL
-              value: INFO
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-m5-production"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            resources:
-              requests:
-                memory: "512Mi"
-                cpu: "300m"
-              limits:
-                memory: "1Gi"
-                cpu: "800m"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - --period=5m
+                - --max-workers=15
+                - --db-adapter=mysql
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: EXTRACTOR_DB_ADAPTER
+                - name: LOG_LEVEL
+                  value: INFO
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-m5-production"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "512Mi"
+                  cpu: "300m"
+                limits:
+                  memory: "1Gi"
+                  cpu: "800m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -189,76 +190,76 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: IfNotPresent
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - --period=15m
-            - --max-workers=12
-            - --db-adapter=mysql
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "384Mi"
-                cpu: "250m"
-              limits:
-                memory: "768Mi"
-                cpu: "600m"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: IfNotPresent
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - --period=15m
+                - --max-workers=12
+                - --db-adapter=mysql
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "384Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "768Mi"
+                  cpu: "600m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -295,66 +296,66 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: IfNotPresent
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - --period=30m
-            - --max-workers=10
-            - --db-adapter=mysql
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "200m"
-              limits:
-                memory: "512Mi"
-                cpu: "500m"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: IfNotPresent
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - --period=30m
+                - --max-workers=10
+                - --db-adapter=mysql
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "200m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -391,132 +392,132 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - --period=1h
-            - --max-workers=8
-            - --db-adapter=mysql
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-h1-production"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "200m"
-              limits:
-                memory: "512Mi"
-                cpu: "500m"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - --period=1h
+                - --max-workers=8
+                - --db-adapter=mysql
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-h1-production"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "200m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -530,7 +531,7 @@ metadata:
     version: production
 spec:
   schedule: "15 0 * * *"
-  successfulJobsHistoryLimit: 5  # Keep more history for daily jobs
+  successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 2
   concurrencyPolicy: Forbid
   jobTemplate:
@@ -540,9 +541,9 @@ spec:
         component: klines-extractor
         interval: d1
     spec:
-      backoffLimit: 3  # More retries for daily jobs
+      backoffLimit: 3
       activeDeadlineSeconds: 2400
-      ttlSecondsAfterFinished: 7200  # Keep for 2 hours
+      ttlSecondsAfterFinished: 7200
       template:
         metadata:
           labels:
@@ -553,73 +554,73 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: IfNotPresent
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - --period=1d
-            - --max-workers=6
-            - --db-adapter=mysql
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "200m"
-              limits:
-                memory: "512Mi"
-                cpu: "500m"
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: IfNotPresent
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - --period=1d
+                - --max-workers=6
+                - --db-adapter=mysql
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "200m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -10,11 +11,9 @@ metadata:
     version: production
 spec:
   schedule: "0 2 * * *"
-  
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -35,139 +34,134 @@ spec:
         spec:
           restartPolicy: Never
           containers:
-          - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_gap_filler
-            
-            args:
-            - --period=5m
-            - --max-workers=3
-            - --db-adapter=mysql
-            - --weekly-chunk-days=7
-            - --max-gap-size-days=3000
-            
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-gap-filler-m5"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "500m"
-              limits:
-                memory: "2Gi"
-                cpu: "1000m"
-            
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-gap-filler
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_gap_filler
+              args:
+                - --period=5m
+                - --max-workers=3
+                - --db-adapter=mysql
+                - --weekly-chunk-days=7
+                - --max-gap-size-days=3000
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-gap-filler,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-gap-filler-m5"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -181,11 +175,9 @@ metadata:
     version: production
 spec:
   schedule: "15 2 * * *"
-  
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -196,7 +188,6 @@ spec:
       backoffLimit: 1
       activeDeadlineSeconds: 21600
       ttlSecondsAfterFinished: 86400
-      
       template:
         metadata:
           labels:
@@ -206,141 +197,135 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
-          - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_gap_filler
-            
-            args:
-            - --period=15m
-            - --max-workers=3
-            - --db-adapter=mysql
-            - --weekly-chunk-days=7
-            - --max-gap-size-day=3000
-            
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-gap-filler-m15"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "500m"
-              limits:
-                memory: "2Gi"
-                cpu: "1000m"
-            
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-gap-filler
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_gap_filler
+              args:
+                - --period=15m
+                - --max-workers=3
+                - --db-adapter=mysql
+                - --weekly-chunk-days=7
+                - --max-gap-size-day=3000
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-gap-filler,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-gap-filler-m15"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -354,11 +339,9 @@ metadata:
     version: production
 spec:
   schedule: "30 2 * * *"
-  
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -369,7 +352,6 @@ spec:
       backoffLimit: 1
       activeDeadlineSeconds: 21600
       ttlSecondsAfterFinished: 86400
-      
       template:
         metadata:
           labels:
@@ -379,141 +361,135 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
-          - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_gap_filler
-            
-            args:
-            - --period=30m
-            - --max-workers=3
-            - --db-adapter=mysql
-            - --weekly-chunk-days=7
-            - --max-gap-size-day=3000
-            
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-gap-filler-m30"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "500m"
-              limits:
-                memory: "2Gi"
-                cpu: "1000m"
-            
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-gap-filler
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_gap_filler
+              args:
+                - --period=30m
+                - --max-workers=3
+                - --db-adapter=mysql
+                - --weekly-chunk-days=7
+                - --max-gap-size-day=3000
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-gap-filler,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-gap-filler-m30"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -527,11 +503,9 @@ metadata:
     version: production
 spec:
   schedule: "45 2 * * *"
-  
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -542,7 +516,6 @@ spec:
       backoffLimit: 1
       activeDeadlineSeconds: 21600
       ttlSecondsAfterFinished: 86400
-      
       template:
         metadata:
           labels:
@@ -552,141 +525,135 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
-          - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_gap_filler
-            
-            args:
-            - --period=1h
-            - --max-workers=3
-            - --db-adapter=mysql
-            - --weekly-chunk-days=7
-            - --max-gap-size-day=3000
-            
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-gap-filler-h1"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "500m"
-              limits:
-                memory: "2Gi"
-                cpu: "1000m"
-            
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL
+            - name: klines-gap-filler
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_gap_filler
+              args:
+                - --period=1h
+                - --max-workers=3
+                - --db-adapter=mysql
+                - --weekly-chunk-days=7
+                - --max-gap-size-day=3000
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-gap-filler,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-gap-filler-h1"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -700,11 +667,9 @@ metadata:
     version: production
 spec:
   schedule: "0 3 * * *"
-  
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
-  
   jobTemplate:
     metadata:
       labels:
@@ -715,7 +680,6 @@ spec:
       backoffLimit: 1
       activeDeadlineSeconds: 21600
       ttlSecondsAfterFinished: 86400
-      
       template:
         metadata:
           labels:
@@ -725,138 +689,132 @@ spec:
             instrumentation.newrelic.com/inject-python: "true"
         spec:
           restartPolicy: Never
-          
           containers:
-          - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            imagePullPolicy: Always
-            
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_gap_filler
-            
-            args:
-            - --period=1d
-            - --max-workers=3
-            - --db-adapter=mysql
-            - --weekly-chunk-days=7
-            - --max-gap-size-day=3000
-            
-            env:
-            - name: BINANCE_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_KEY
-            - name: BINANCE_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: BINANCE_API_SECRET
-            - name: MYSQL_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: MYSQL_URI
-            - name: LOG_LEVEL
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: ENVIRONMENT
-            - name: DB_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: DB_ADAPTER
-            - name: NATS_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_URL
-            - name: NATS_ENABLED
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: NATS_ENABLED
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: K8S_DEPLOYMENT_NAME
-              value: "binance-klines-gap-filler-d1"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "500m"
-              limits:
-                memory: "2Gi"
-                cpu: "1000m"
-            
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 1000
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                - ALL 
+            - name: klines-gap-filler
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              imagePullPolicy: Always
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_gap_filler
+              args:
+                - --period=1d
+                - --max-workers=3
+                - --db-adapter=mysql
+                - --weekly-chunk-days=7
+                - --max-gap-size-day=3000
+              env:
+                - name: BINANCE_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_KEY
+                - name: BINANCE_API_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: BINANCE_API_SECRET
+                - name: MYSQL_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: MYSQL_URI
+                - name: LOG_LEVEL
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: ENVIRONMENT
+                - name: DB_ADAPTER
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: DB_ADAPTER
+                - name: NATS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_URL
+                - name: NATS_ENABLED
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: NATS_ENABLED
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-gap-filler,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: K8S_POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: K8S_DEPLOYMENT_NAME
+                  value: "binance-klines-gap-filler-d1"
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "500m"
+                limits:
+                  memory: "2Gi"
+                  cpu: "1000m"
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop:
+                    - ALL

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -5,20 +5,17 @@ metadata:
   name: petrosa-common-config
   namespace: petrosa-apps
 data:
-
   DB_ADAPTER: "mongodb"
-  DB_BATCH_SIZE: "500"  # Reduced for memory constraints
+  DB_BATCH_SIZE: "500"
   MAX_RETRIES: "3"
   RETRY_BACKOFF_SECONDS: "2"
-
   LOG_LEVEL: "INFO"
-  API_RATE_LIMIT_PER_MINUTE: "600"  # Reduced to avoid overwhelming
+  API_RATE_LIMIT_PER_MINUTE: "600"
   REQUEST_DELAY_SECONDS: "0.2"
-
   SUPPORTED_INTERVALS: "1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d"
   DEFAULT_PERIOD: "15m"
-  DEFAULT_SYMBOLS: "BTCUSDT,ETHUSDT,BNBUSDT,ADAUSDT,DOTUSDT,LINKUSDT,LTCUSDT,BCHUSDT,XLMUSDT,XRPUSDT"
-
+  DEFAULT_SYMBOLS: >
+    "BTCUSDT,ETHUSDT,BNBUSDT,ADAUSDT,DOTUSDT,LINKUSDT,LTCUSDT,BCHUSDT,XLMUSDT,XRPUSDT"
   DEFAULT_START_DATE: "2023-01-01T00:00:00Z"
   TIMEZONE: "UTC"
   OTEL_SERVICE_NAME: "petrosa-binance-extractor"
@@ -37,7 +34,7 @@ metadata:
     database: mongodb
     interval: 5m
 spec:
-  schedule: "*/5 * * * *"  # Every 5 minutes
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
@@ -55,92 +52,92 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - "--period=5m"
-            - "--max-workers=15"
-            - "--db-adapter=mongodb"
-            env:
-            - name: MONGODB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: mongodb-connection-string
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_ADAPTER
-            - name: DB_BATCH_SIZE
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_BATCH_SIZE
-            - name: LOG_LEVEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "400Mi"  # Within 512MB constraint
-                cpu: "500m"
-            imagePullPolicy: Always
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - "--period=5m"
+                - "--max-workers=15"
+                - "--db-adapter=mongodb"
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: mongodb-connection-string
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_ADAPTER
+                - name: DB_BATCH_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_BATCH_SIZE
+                - name: LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "400Mi"
+                  cpu: "500m"
+              imagePullPolicy: Always
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -171,92 +168,92 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - "--period=15m"
-            - "--max-workers=15"
-            - "--db-adapter=mongodb"
-            env:
-            - name: MONGODB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: mongodb-connection-string
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_ADAPTER
-            - name: DB_BATCH_SIZE
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_BATCH_SIZE
-            - name: LOG_LEVEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "400Mi"
-                cpu: "500m"
-            imagePullPolicy: Always
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - "--period=15m"
+                - "--max-workers=15"
+                - "--db-adapter=mongodb"
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: mongodb-connection-string
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_ADAPTER
+                - name: DB_BATCH_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_BATCH_SIZE
+                - name: LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "400Mi"
+                  cpu: "500m"
+              imagePullPolicy: Always
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -287,92 +284,92 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - "--period=30m"
-            - "--max-workers=15"
-            - "--db-adapter=mongodb"
-            env:
-            - name: MONGODB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: mongodb-connection-string
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_ADAPTER
-            - name: DB_BATCH_SIZE
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_BATCH_SIZE
-            - name: LOG_LEVEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "400Mi"
-                cpu: "500m"
-            imagePullPolicy: Always
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - "--period=30m"
+                - "--max-workers=15"
+                - "--db-adapter=mongodb"
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: mongodb-connection-string
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_ADAPTER
+                - name: DB_BATCH_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_BATCH_SIZE
+                - name: LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "400Mi"
+                  cpu: "500m"
+              imagePullPolicy: Always
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -403,92 +400,92 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - "--period=1h"
-            - "--max-workers=15"
-            - "--db-adapter=mongodb"
-            env:
-            - name: MONGODB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: mongodb-connection-string
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_ADAPTER
-            - name: DB_BATCH_SIZE
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_BATCH_SIZE
-            - name: LOG_LEVEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "400Mi"
-                cpu: "500m"
-            imagePullPolicy: Always
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - "--period=1h"
+                - "--max-workers=15"
+                - "--db-adapter=mongodb"
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: mongodb-connection-string
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_ADAPTER
+                - name: DB_BATCH_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_BATCH_SIZE
+                - name: LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "400Mi"
+                  cpu: "500m"
+              imagePullPolicy: Always
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -519,89 +516,89 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
-            command:
-            - opentelemetry-instrument
-            - python
-            - -m
-            - jobs.extract_klines_production
-            args:
-            - "--period=1d"
-            - "--max-workers=15"
-            - "--db-adapter=mongodb"
-            env:
-            - name: MONGODB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: mongodb-connection-string
-            - name: DB_ADAPTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_ADAPTER
-            - name: DB_BATCH_SIZE
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: DB_BATCH_SIZE
-            - name: LOG_LEVEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: LOG_LEVEL
-            - name: ENVIRONMENT
-              value: production
-            - name: ENABLE_OTEL
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: ENABLE_OTEL
-            - name: OTEL_SERVICE_VERSION
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_SERVICE_VERSION
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_EXPORTER_OTLP_ENDPOINT
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
-            - name: OTEL_METRICS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_METRICS_EXPORTER
-            - name: OTEL_TRACES_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_TRACES_EXPORTER
-            - name: OTEL_LOGS_EXPORTER
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_LOGS_EXPORTER
-            - name: OTEL_PROPAGATORS
-              valueFrom:
-                configMapKeyRef:
-                  name: petrosa-common-config
-                  key: OTEL_PROPAGATORS
-            - name: OTEL_EXPORTER_OTLP_HEADERS
-              valueFrom:
-                secretKeyRef:
-                  name: petrosa-sensitive-credentials
-                  key: OTEL_EXPORTER_OTLP_HEADERS
-            - name: OTEL_NO_AUTO_INIT
-              value: "1"
-            resources:
-              requests:
-                memory: "256Mi"
-                cpu: "100m"
-              limits:
-                memory: "400Mi"
-                cpu: "500m"
-            imagePullPolicy: Always 
+            - name: klines-extractor
+              image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+              command:
+                - opentelemetry-instrument
+                - python
+                - -m
+                - jobs.extract_klines_production
+              args:
+                - "--period=1d"
+                - "--max-workers=15"
+                - "--db-adapter=mongodb"
+              env:
+                - name: MONGODB_URI
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: mongodb-connection-string
+                - name: DB_ADAPTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_ADAPTER
+                - name: DB_BATCH_SIZE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: DB_BATCH_SIZE
+                - name: LOG_LEVEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: LOG_LEVEL
+                - name: ENVIRONMENT
+                  value: production
+                - name: ENABLE_OTEL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: ENABLE_OTEL
+                - name: OTEL_SERVICE_VERSION
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_SERVICE_VERSION
+                - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_EXPORTER_OTLP_ENDPOINT
+                - name: OTEL_RESOURCE_ATTRIBUTES
+                  value: "service.name=binance-extractor,service.version=2.0.0"
+                - name: OTEL_METRICS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_METRICS_EXPORTER
+                - name: OTEL_TRACES_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_TRACES_EXPORTER
+                - name: OTEL_LOGS_EXPORTER
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_LOGS_EXPORTER
+                - name: OTEL_PROPAGATORS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: petrosa-common-config
+                      key: OTEL_PROPAGATORS
+                - name: OTEL_EXPORTER_OTLP_HEADERS
+                  valueFrom:
+                    secretKeyRef:
+                      name: petrosa-sensitive-credentials
+                      key: OTEL_EXPORTER_OTLP_HEADERS
+                - name: OTEL_NO_AUTO_INIT
+                  value: "1"
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "400Mi"
+                  cpu: "500m"
+              imagePullPolicy: Always


### PR DESCRIPTION
This PR fixes all YAML indentation and formatting issues in the following files:\n- k8s/klines-all-timeframes-cronjobs.yaml\n- k8s/klines-gap-filler-cronjob.yaml\n- k8s/klines-mongodb-production.yaml\n\nAll files now pass yamllint and kubectl apply should work in CI/CD.\n\nCloses: #yaml-formatting-bugs