### PR TITLE
Fix workflow version output propagation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixed the workflow version output propagation to ensure IMAGE_TAG is always set correctly in the deploy step.

### Problem
The  job was receiving an empty  because the  job wasn't exposing its version output to downstream jobs.

### Solution
Added  to the  job:


### Changes Made
- **File**: 
- **Job**: 
- **Added**:  section to expose version to downstream jobs

### Result
- ✅  job now receives the correct incremented version
- ✅  is always set to the latest version from the workflow
- ✅ No more empty version placeholders in Kubernetes manifests

### Version Increment Logic
The version is incremented in the  job's "Generate Semantic Version" step, which:
1. Finds the latest semantic version tag
2. Increments the PATCH number (e.g., v1.0.31 → v1.0.32)
3. Creates a new tag and pushes it to GitHub
4. Makes the version available to downstream jobs via outputs