### PR TITLE
Remove latest Docker tag to ensure only versioned images are pushed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,6 @@ jobs:
         images: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor
         tags: |
           type=raw,value=${{ steps.version.outputs.version }}
-          type=raw,value=latest
     - name: Build and Push Docker Image
       id: build
       uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

Fixed the fundamental flaw where both versioned and latest Docker images were being pushed. Now only versioned images are pushed to Docker Hub.

### Problem
The workflow was pushing both:
-  (versioned)
-  (latest)

This created confusion and potential deployment issues.

### Solution
Removed the  tag from the Docker metadata action configuration.

### Changes Made
**File**: 
**Section**:  step
**Removed**:  from tags configuration

### Before


### After


### Benefits
- ✅ **Only versioned images are pushed** (e.g., v1.0.32)
- ✅ **Each deployment uses a unique, traceable image**
- ✅ **No confusion between latest and versioned images**
- ✅ **Kubernetes manifests always use the specific version**
- ✅ **Better deployment traceability and rollback capability**

### Result
Now when the workflow runs:
1. Creates version tag (e.g., v1.0.32)
2. Builds and pushes only 
3. Updates Kubernetes manifests to use the specific version
4. Deploys with the exact versioned image