### PR TITLE
fix: Fix Docker tag version issue in CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -69,12 +71,9 @@ jobs:
     - name: Determine Version
       id: version
       run: |
-        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-          VERSION="${{ github.ref_name }}"
-        else
-          VERSION="${{ needs.create-release.outputs.version }}"
-        fi
+        VERSION="${{ needs.create-release.outputs.version }}"
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "Using version: ${VERSION}"
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx


### PR DESCRIPTION
## Problem
The Docker build was failing with 'tag is needed when pushing to registry' error because the IMAGE_TAG variable was empty.

## Root Cause
The  job wasn't exposing its version output, so the  job couldn't access the generated version.

## Solution
1. Added  section to  job to expose the version
2. Simplified the version determination in  job to use the version from 

## Changes
- Added  to create-release job
- Simplified version determination in build-and-push job to use 

This ensures the Docker image gets properly tagged with the incremented version.