### PR TITLE
Trigger CI/CD build for MongoDB timeseries fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,3 +848,4 @@ opentelemetry-instrument python -m jobs.extract_klines --symbols BTCUSDT --perio
 
 ## Gap Filler Job# Trigger CI/CD deployment
 # Trigger deployment
+# Trigger CI/CD build for MongoDB fix


### PR DESCRIPTION
## Purpose
Trigger CI/CD pipeline to build new Docker image with MongoDB timeseries collection fix.

## Changes
- MongoDB adapter updated to use InsertOne instead of UpdateOne for timeseries collections
- All tests passing
- Ready for deployment

## Expected Result
- New Docker image built with MongoDB fix
- Automatic deployment to Kubernetes cluster
- MongoDB jobs should successfully write to Atlas