### PR TITLE
feat: replace hardcoded service versions with VERSION_PLACEHOLDER

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -87,7 +87,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -508,7 +508,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -122,7 +122,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
+              value: "service.name=binance-gap-filler,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -301,7 +301,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
+              value: "service.name=binance-gap-filler,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -480,7 +480,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
+              value: "service.name=binance-gap-filler,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -659,7 +659,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
+              value: "service.name=binance-gap-filler,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -838,7 +838,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-gap-filler,service.version=2.0.0"
+              value: "service.name=binance-gap-filler,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -89,7 +89,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -262,7 +262,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -435,7 +435,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -608,7 +608,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:
@@ -781,7 +781,7 @@ spec:
                   name: petrosa-common-config
                   key: OTEL_EXPORTER_OTLP_ENDPOINT
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name=binance-extractor,service.version=2.0.0"
+              value: "service.name=binance-extractor,service.version=VERSION_PLACEHOLDER"
             - name: OTEL_METRICS_EXPORTER
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Changes Made

- Replace hardcoded service.version=2.0.0 with service.version=VERSION_PLACEHOLDER
- Update all OTEL_RESOURCE_ATTRIBUTES across all cronjob files
- Ensure compliance with Petrosa auto-increment system
- Enable seamless integration with CI/CD pipelines and version management

## Files Changed
- k8s/klines-mongodb-production.yaml
- k8s/klines-all-timeframes-cronjobs.yaml
- k8s/klines-gap-filler-cronjob.yaml

## Testing
- All service versions now use VERSION_PLACEHOLDER
- No hardcoded versions remain in project templates
- Ready for auto-increment system integration