### PR TITLE
fix: Correct configmap key names to match existing petrosa-common-config

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -58,12 +58,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: LOG_LEVEL
+              key: log-level
         - name: ENVIRONMENT
           valueFrom:
             configMapKeyRef:
               name: petrosa-common-config
-              key: ENVIRONMENT
+              key: environment
         - name: ENABLE_OTEL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
This PR fixes the configmap key name mismatches that were causing CreateContainerConfigError in the socket client and data extractor deployments.

The issue was that the deployments were looking for:
- LOG_LEVEL (uppercase) but the configmap has log-level (lowercase)
- ENVIRONMENT (uppercase) but the configmap has environment (lowercase)

This fix ensures the deployments use the correct key names that exist in the petrosa-common-config configmap.