### PR TITLE
fix: Correct image names in cronjob manifests to match deployment

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -148,6 +148,7 @@ make k8s-clean
 
 ## Kubernetes Configuration
 ## CRITICAL: ALWAYS FOLLOW THESE RULES
+- **AVOID INTERACTIVE CLI COMMANDS AT ALL COSTS**: Never suggest or use interactive commands that require user input, confirmation, or manual intervention. All commands must be non-interactive and automated.
 - **BEFORE making any changes**: Check `docs/REPOSITORY_SETUP_GUIDE.md` and `docs/QUICK_REFERENCE.md`
 - **WHEN suggesting kubectl commands**: Always include `--kubeconfig=k8s/kubeconfig.yaml`
 - **WHEN dealing with credentials**: ONLY use existing secret `petrosa-sensitive-credentials`
@@ -336,6 +337,7 @@ When fixing the pipeline, go until it is fully green and stop only when CI/CD on
 - Monitor error rates and alert on thresholds
 
 ## Always Reference
+- **AVOID INTERACTIVE CLI COMMANDS AT ALL COSTS**: Never suggest or use interactive commands that require user input, confirmation, or manual intervention. All commands must be non-interactive and automated.
 - Check project-specific `README.md` for detailed documentation
 - Use `Makefile` for all common commands
 - Use `scripts/` directory for automation and troubleshooting

--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -206,7 +206,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             command:
             - opentelemetry-instrument
@@ -327,7 +327,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             command:
             - opentelemetry-instrument
@@ -423,7 +423,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -600,7 +600,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: IfNotPresent
             command:
             - opentelemetry-instrument

--- a/k8s/klines-gap-filler-cronjob.yaml
+++ b/k8s/klines-gap-filler-cronjob.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -214,7 +214,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -393,7 +393,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -572,7 +572,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -751,7 +751,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-gap-filler
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -38,7 +38,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -211,7 +211,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -384,7 +384,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -557,7 +557,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument
@@ -730,7 +730,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: klines-extractor
-            image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
+            image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
             imagePullPolicy: Always
             command:
             - opentelemetry-instrument


### PR DESCRIPTION
This PR fixes the critical issue where cronjob manifests were using the wrong Docker image name.

**Issue**: Cronjob manifests were using  instead of , causing ImagePullBackOff errors.

**Fix**: Updated all cronjob manifests to use the correct image name .

**Files Fixed**:
- k8s/klines-mongodb-production.yaml
- k8s/klines-all-timeframes-cronjobs.yaml  
- k8s/klines-gap-filler-cronjob.yaml

This should resolve the deployment issues and allow the data extractor to pull the correct Docker images.