### PR TITLE
fix: Use correct Docker Hub repository name (petrosa-binance-extractor)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-data-extractor
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor
         tags: |
           type=raw,value=${{ steps.version.outputs.version }}
     - name: Build and Push Docker Image
@@ -131,13 +131,13 @@ jobs:
         find k8s/ -name "*.yaml" -o -name "*.yml" | xargs sed -i "s|VERSION_PLACEHOLDER|${IMAGE_TAG}|g"
 
         # Also replace the image name to use the correct format with secrets
-        find k8s/ -name "*.yaml" -o -name "*.yml" | xargs sed -i "s|petrosa/petrosa-binance-data-extractor|${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-data-extractor|g"
+        find k8s/ -name "*.yaml" -o -name "*.yml" | xargs sed -i "s|yurisa2/petrosa-binance-data-extractor|${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor|g"
 
-        echo "Updated manifests with image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-data-extractor:${IMAGE_TAG}"
+        echo "Updated manifests with image: ${{ secrets.DOCKERHUB_USERNAME }}/petrosa-binance-extractor:${IMAGE_TAG}"
 
         # Verify the changes
         echo "Verifying image tag updates:"
-        grep -r "image:.*petrosa-binance-data-extractor" k8s/ || echo "No image references found"
+        grep -r "image:.*petrosa-binance-extractor" k8s/ || echo "No image references found"
 
         # Double-check that no VERSION_PLACEHOLDER remain
         PLACEHOLDER_COUNT=$(grep -r "VERSION_PLACEHOLDER" k8s/ | wc -l || echo "0")

--- a/README.md
+++ b/README.md
@@ -447,3 +447,4 @@ For support and questions:
 ---
 
 **🚀 Production-ready historical data extraction system for Binance cryptocurrency exchange**
+# Test build trigger

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: data-extractor
-        image: yurisa2/petrosa-binance-data-extractor:VERSION_PLACEHOLDER
+        image: yurisa2/petrosa-binance-extractor:VERSION_PLACEHOLDER
         imagePullPolicy: Always
         command:
         - opentelemetry-instrument


### PR DESCRIPTION
This PR fixes the critical Docker Hub repository name mismatch that was causing deployment failures.

**Root Cause**: 
- CI/CD workflow was trying to push to  
- But the actual Docker Hub repository is named 
- This caused all image builds to fail with 'manifest unknown' errors

**Fix**:
- Updated workflow to push to correct repository: 
- Updated deployment manifest to pull from correct repository
- Updated image name replacement in workflow

**Impact**: 
- This should resolve all ImagePullBackOff errors
- Data extractor deployment should now work correctly
- Auto-increment versioning system will work as expected