### PR TITLE
fix: update OTEL endpoint to Grafana Alloy collector

### DIFF
--- a/k8s/common-configmap.yaml
+++ b/k8s/common-configmap.yaml
@@ -22,7 +22,7 @@ data:
   # OpenTelemetry configuration
   ENABLE_OTEL: "true"
   OTEL_SERVICE_VERSION: "VERSION_PLACEHOLDER"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://grafana-alloy.observability.svc.cluster.local:4317"
   OTEL_METRICS_EXPORTER: "otlp"
   OTEL_TRACES_EXPORTER: "otlp"
   OTEL_LOGS_EXPORTER: "otlp"


### PR DESCRIPTION
## Critical Fix
THIS IS THE ROOT CAUSE of missing traces, logs, and metrics!

## Problem
Services were configured to send OTLP data to:
```
http://otel-collector:4317
```

But this endpoint **does not exist** in the cluster!

## Solution
Updated OTEL_EXPORTER_OTLP_ENDPOINT to the correct Grafana Alloy collector:
```
http://grafana-alloy.observability.svc.cluster.local:4317
```

## Impact
✅ Traces will now reach Grafana Cloud
✅ Logs will now reach Grafana Cloud  
✅ Metrics will now reach Grafana Cloud

This fixes the missing observability data issue.

## Deployment
URGENT: Ready for immediate merge and deployment.