### PR TITLE
fix: Add OTLP log export to binance-data-extractor

### DIFF
--- a/otel_init.py
+++ b/otel_init.py
@@ -1,23 +1,31 @@
 """
-OpenTelemetry initialization for the Socket Client service.
+OpenTelemetry initialization for the Binance Data Extractor service.
 
 This module sets up OpenTelemetry instrumentation for observability
-and monitoring of the WebSocket client service.
+and monitoring of the data extraction jobs.
 """
 
+import logging
 import os
 
 from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.instrumentation.urllib3 import URLLib3Instrumentor
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Global logger provider for attaching handlers
+_global_logger_provider = None
+_otlp_logging_handler = None
 
 
 def setup_telemetry(
@@ -148,16 +156,43 @@ def setup_telemetry(
         except Exception as e:
             print(f"⚠️  Failed to set up OpenTelemetry metrics: {e}")
 
-    # Set up logging instrumentation if enabled
-    if enable_logs:
+    # Set up logging export via OTLP if enabled
+    if enable_logs and otlp_endpoint:
+        global _global_logger_provider
         try:
-            LoggingInstrumentor().instrument(
-                set_logging_format=True, log_level=os.getenv("LOG_LEVEL", "INFO")
+            # Enrich logs with trace context
+            # set_logging_format=False to avoid clearing existing handlers
+            LoggingInstrumentor().instrument(set_logging_format=False)
+
+            # Parse log headers
+            log_headers_env = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
+            log_headers: dict[str, str] | None = None
+            if log_headers_env:
+                log_headers_list = [
+                    tuple(h.split("=", 1))
+                    for h in log_headers_env.split(",")
+                    if "=" in h
+                ]
+                log_headers = dict(log_headers_list)
+
+            log_exporter = OTLPLogExporter(
+                endpoint=otlp_endpoint,
+                headers=log_headers,
             )
-            print(f"✅ OpenTelemetry logging enabled for {service_name}")
+
+            logger_provider = LoggerProvider(resource=resource)
+            logger_provider.add_log_record_processor(
+                BatchLogRecordProcessor(log_exporter)
+            )
+            _global_logger_provider = logger_provider
+
+            print(f"✅ OpenTelemetry logging export configured for {service_name}")
+
+            # For CLI jobs, attach handler immediately after setup
+            attach_logging_handler_simple()
 
         except Exception as e:
-            print(f"⚠️  Failed to set up OpenTelemetry logging: {e}")
+            print(f"⚠️  Failed to set up OpenTelemetry logging export: {e}")
 
     # Set up HTTP instrumentation
     try:
@@ -171,6 +206,47 @@ def setup_telemetry(
     print(f"🚀 OpenTelemetry setup completed for {service_name} v{service_version}")
 
 
+def attach_logging_handler_simple():
+    """
+    Attach OTLP logging handler to root logger.
+
+    For CLI/CronJob scripts and async services without Uvicorn.
+    This attaches the OTLP handler to the root logger only.
+    """
+    global _global_logger_provider, _otlp_logging_handler
+
+    if _global_logger_provider is None:
+        print("⚠️  Logger provider not configured - logging export not available")
+        return False
+
+    try:
+        root_logger = logging.getLogger()
+
+        # Check if handler already attached
+        if _otlp_logging_handler is not None:
+            if _otlp_logging_handler in root_logger.handlers:
+                print("✅ OTLP logging handler already attached")
+                return True
+
+        # Create and attach handler
+        handler = LoggingHandler(
+            level=logging.NOTSET,
+            logger_provider=_global_logger_provider,
+        )
+
+        root_logger.addHandler(handler)
+        _otlp_logging_handler = handler
+
+        print("✅ OTLP logging handler attached to root logger")
+        print(f"   Total handlers: {len(root_logger.handlers)}")
+
+        return True
+
+    except Exception as e:
+        print(f"⚠️  Failed to attach logging handler: {e}")
+        return False
+
+
 def get_tracer(name: str = None) -> trace.Tracer:
     """
     Get a tracer instance.
@@ -181,7 +257,7 @@ def get_tracer(name: str = None) -> trace.Tracer:
     Returns:
         Tracer instance
     """
-    return trace.get_tracer(name or "socket-client")
+    return trace.get_tracer(name or "binance-data-extractor")
 
 
 def get_meter(name: str = None) -> metrics.Meter:
@@ -194,7 +270,7 @@ def get_meter(name: str = None) -> metrics.Meter:
     Returns:
         Meter instance
     """
-    return metrics.get_meter(name or "socket-client")
+    return metrics.get_meter(name or "binance-data-extractor")
 
 
 # Auto-setup if environment variable is set and not disabled


### PR DESCRIPTION
## Summary

Apply lessons learned from tradeengine logging fix (PR #75) to enable complete observability for the binance-data-extractor service.

## Changes

### Updated `otel_init.py`

- Added OTLP log export imports and configuration
- Added `attach_logging_handler_simple()` function for root logger attachment
- Configured log export with BatchLogRecordProcessor
- Auto-attach handler immediately after OTEL setup

### Architecture-Specific Implementation

The binance-data-extractor service runs **CLI/CronJob scripts** (no web server), so:
- ✅ Attach to **root logger only** (no uvicorn loggers needed)
- ✅ Handler attached **automatically** when otel_init.py is imported
- ✅ No changes needed to job entry points

This is different from tradeengine which needs uvicorn logger attachment because it runs FastAPI/Uvicorn.

## Testing

The fix will enable OTLP log export for all job scripts:
- `jobs/extract_klines.py`
- `jobs/extract_funding.py`
- `jobs/extract_trades.py`
- All other extraction jobs

## Expected Outcome

After deployment:
- ✅ Job execution logs will appear in Grafana Cloud Loki
- ✅ Traces and metrics continue working
- ✅ Complete observability achieved (metrics, traces, logs)

## Verification

Check Grafana Loki for logs:
```logql
{service_name="binance-data-extractor"} |= ""
```

Refs: Part of observability rollout across all Petrosa services