### PR TITLE
fix: add OTLP logging handler to binance-extractor cronjobs

### DIFF
--- a/jobs/extract_klines_mongodb.py
+++ b/jobs/extract_klines_mongodb.py
@@ -334,6 +334,14 @@ def main():
     # Setup logging
     logger = setup_logging(level=args.log_level)
 
+    # Attach OTLP logging handler after logging is configured
+    try:
+        from otel_init import attach_logging_handler_simple
+
+        attach_logging_handler_simple()
+    except Exception as e:
+        logger.warning(f"Failed to attach OTLP logging handler: {e}")
+
     # Get symbols list
     symbols = get_symbols_list(args)
 


### PR DESCRIPTION
## Summary
This PR adds the missing OTLP logging handler to enable proper log export from binance-extractor cronjobs to Grafana Cloud.

## Changes
- Add `attach_logging_handler_simple()` call after `setup_logging()` in `main()` function
- Follows the same pattern used in socket-client and realtime-strategies services

## Testing
- Manually triggered a test job using `kubectl create job --from=cronjob/binance-klines-m5-mongodb-production`
- Verified logs include proper OpenTelemetry metadata (`otelSpanID`, `otelTraceID`, `otelServiceName`)
- Job completed successfully with structured OTLP logs

## Impact
- **Before**: binance-extractor had traces but no logs in Grafana Cloud
- **After**: binance-extractor now exports both traces and logs to Grafana Cloud

## Related Issue
Fixes missing logs for binance-extractor service in observability stack.