### PR TITLE
fix: increase cronjob timeouts and add DEFAULT_SYMBOLS for 10-symbol support

### DIFF
--- a/k8s/klines-all-timeframes-cronjobs.yaml
+++ b/k8s/klines-all-timeframes-cronjobs.yaml
@@ -22,7 +22,7 @@ spec:
         interval: m5
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 300
+      activeDeadlineSeconds: 900
       ttlSecondsAfterFinished: 1800
       template:
         metadata:
@@ -158,6 +158,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "512Mi"
@@ -197,7 +202,7 @@ spec:
         interval: m15
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 1200
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -316,7 +321,7 @@ spec:
         interval: m30
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 900
+      activeDeadlineSeconds: 1800
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -410,7 +415,7 @@ spec:
         interval: h1
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 1200
+      activeDeadlineSeconds: 2400
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -546,6 +551,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "256Mi"

--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -170,6 +170,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "512Mi"
@@ -347,6 +357,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "384Mi"
@@ -524,6 +544,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "256Mi"
@@ -701,6 +731,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "256Mi"
@@ -878,6 +918,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
+            - name: DEFAULT_SYMBOLS
+              valueFrom:
+                configMapKeyRef:
+                  name: petrosa-common-config
+                  key: DEFAULT_SYMBOLS
             resources:
               requests:
                 memory: "256Mi"


### PR DESCRIPTION
## Problem
Data extraction cronjobs were failing because:
1. Timeouts were too short for extracting 10 symbols (vs. previous 3 symbols)
2. Missing DEFAULT_SYMBOLS environment variable caused fallback to hardcoded 3 symbols

This resulted in TA bot not receiving data for 7 out of 10 configured trading pairs.

## Changes
### Timeout Increases
- **m5**: 300s → 900s (15 minutes)
- **m15**: 600s → 1200s (20 minutes)
- **m30**: 900s → 1800s (30 minutes)
- **h1**: 1200s → 2400s (40 minutes)
- **d1**: 2400s (no change - already sufficient)

### Environment Variables
- Added `DEFAULT_SYMBOLS` environment variable to all production cronjobs
- Reads from `petrosa-common-config` ConfigMap (10 symbols configured)

## Impact
- ✅ Data extraction will now process all 10 trading pairs
- ✅ TA bot will receive data for all configured symbols
- ✅ Trade engine can execute signals across all 10 pairs
- ✅ Eliminates job timeout failures

## Testing
- CI/CD checks will validate manifest syntax
- Deployment will be automatic after merge
- Monitor next cronjob runs for successful completion

## Related Issues
- Fixes cronjob timeout issues with 10-symbol configuration
- Resolves TA bot "no logs" issue (was waiting for data)

##Trading Pairs Affected
BTCUSDT, ETHUSDT, BNBUSDT, ADAUSDT, DOTUSDT, LINKUSDT, LTCUSDT, BCHUSDT, XLMUSDT, XRPUSDT