### PR TITLE
Fix: Remove --incremental argument from Data Manager CronJobs

### DIFF
--- a/k8s/klines-data-manager-production.yaml
+++ b/k8s/klines-data-manager-production.yaml
@@ -44,7 +44,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=5m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -237,7 +236,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=15m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -420,7 +418,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=30m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -603,7 +600,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=1h
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -786,7 +782,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=1d
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:


### PR DESCRIPTION
This PR fixes the CronJob failures by removing the unsupported --incremental argument.

## Problem:
- Data Manager CronJobs were failing with: 'error: unrecognized arguments: --incremental'
- The extract_klines_data_manager.py script does not support this flag

## Solution:
- Remove --incremental argument from all 5 Data Manager CronJobs (5m, 15m, 30m, 1h, 1d)

## Impact:
- Fixes all Data Manager CronJob argument errors
- Jobs will run successfully on schedule