### PR TITLE
Fix: Add missing health() and close() methods to BaseDataManagerClient

### DIFF
--- a/clients/data_manager_client.py
+++ b/clients/data_manager_client.py
@@ -114,6 +114,21 @@ class BaseDataManagerClient:
             raise ConnectionError(f"Connection failed: {e}")
         except requests.exceptions.HTTPError as e:
             raise APIError(f"API error: {e}")
+    
+    def health(self) -> dict:
+        """Check Data Manager health."""
+        url = f"{self.base_url}/health"
+        try:
+            response = self.session.get(url, timeout=5)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            return {"status": "unhealthy", "error": str(e)}
+    
+    def close(self) -> None:
+        """Close the HTTP session."""
+        if self.session:
+            self.session.close()
 
 
 class DataManagerClient:


### PR DESCRIPTION
This PR fixes the Data Manager health check failures in CronJobs.

## Problem:
- CronJobs failing with: 'BaseDataManagerClient' object has no attribute 'health'
- Also missing close() method for proper cleanup

## Solution:
- Add health() method to check Data Manager service health via /health endpoint
- Add close() method to properly close HTTP session
- Both methods are called by the DataManagerClient wrapper

## Impact:
- Fixes all Data Manager CronJob health check failures
- Proper resource cleanup on job completion