### PR TITLE
Fix: Remove await from synchronous health() and close() calls

### DIFF
--- a/clients/data_manager_client.py
+++ b/clients/data_manager_client.py
@@ -475,7 +475,7 @@ class DataManagerClient:
             Health status information
         """
         try:
-            health = await self._client.health()
+            health = self._client.health()  # Synchronous call, no await
             logger.info(f"Data Manager health check: {health.get('status', 'unknown')}")
             return health
         except Exception as e:
@@ -485,7 +485,7 @@ class DataManagerClient:
     async def close(self):
         """Close the client connection."""
         try:
-            await self._client.close()
+            self._client.close()  # Synchronous call, no await
             logger.info("Data Manager client closed")
         except Exception as e:
             logger.warning(f"Error closing Data Manager client: {e}")


### PR DESCRIPTION
This PR fixes the async/sync mismatch in the Data Manager client.

## Problem:
- Health check failing with: "object dict can't be used in 'await' expression"
- BaseDataManagerClient.health() and close() are synchronous methods
- Wrapper was incorrectly trying to await them

## Solution:
- Remove await from health() call in health_check()
- Remove await from close() call in close()

## Impact:
- Fixes Data Manager CronJob health check errors
- Proper synchronous execution of HTTP calls