### PR TITLE
Fix: Resolve logger event argument conflict

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -122,7 +122,6 @@ def log_extraction_start(
 ):
     """Log extraction start with structured data."""
     log.info(
-        "Starting data extraction",
         event="extraction_start",
         extractor_type=extractor_type,
         symbols=symbols,


### PR DESCRIPTION
This PR fixes the TypeError in log_extraction_start causing CronJob failures.

## Problem:
- CronJobs failing with: TypeError: BoundLogger.info() got multiple values for argument 'event'
- Cannot have both positional event message and keyword event parameter

## Solution:
- Remove duplicate positional event string
- Keep only keyword event parameter

## Impact:
- Fixes Data Manager CronJob logging errors