### PR TITLE
Fix: Use correct /health/liveness endpoint

### DIFF
--- a/clients/data_manager_client.py
+++ b/clients/data_manager_client.py
@@ -117,7 +117,7 @@ class BaseDataManagerClient:
     
     def health(self) -> dict:
         """Check Data Manager health."""
-        url = f"{self.base_url}/health"
+        url = f"{self.base_url}/health/liveness"
         try:
             response = self.session.get(url, timeout=5)
             response.raise_for_status()


### PR DESCRIPTION
This PR fixes the Data Manager health check to use the correct endpoint.

## Problem:
- Health check failing with HTTP 422
- Using /health which requires query parameters
- Data Manager liveness endpoint is at /health/liveness

## Solution:
- Update health() method to use /health/liveness endpoint

## Impact:
- Fixes Data Manager health check HTTP 422 errors
- Proper health validation before data operations