### PR TITLE
[BUG] Fix security scan not blocking PR merges

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -84,6 +84,10 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # Required for SARIF upload
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -122,7 +126,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+          exit-code: '1'  # Fail if vulnerabilities found
           ignore-unfixed: true
 
       - name: Upload Trivy results


### PR DESCRIPTION
Part of PetroSa2/petrosa_k8s#77

- Added permissions: security-events: write
- Changed exit-code: '0' to '1' to block on vulnerabilities

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `security-scan` workflow to grant required permissions and make Trivy exit with failure to block PRs with vulnerabilities.
> 
> - **CI Workflow (`.github/workflows/ci-checks.yml`)**:
>   - **Security Scan job**:
>     - Add `permissions`: `contents: read`, `security-events: write`, `actions: read` for SARIF upload.
>     - Set Trivy `exit-code` to `1` to fail the job on `CRITICAL`/`HIGH` vulnerabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87913a74890c5e4f8f58ac7c32de285a24bab38b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->