### PR TITLE
[BUG] CronJob activeDeadlineSeconds timeout too short for data-manager jobs (closes #139)

### DIFF
--- a/k8s/klines-data-manager-production.yaml
+++ b/k8s/klines-data-manager-production.yaml
@@ -24,7 +24,7 @@ spec:
         interval: 5m
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 900
       ttlSecondsAfterFinished: 1800
       template:
         metadata:
@@ -216,7 +216,7 @@ spec:
         interval: 15m
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 1200
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -398,7 +398,7 @@ spec:
         interval: 30m
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 900
+      activeDeadlineSeconds: 1200
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -580,7 +580,7 @@ spec:
         interval: 1h
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 1200
+      activeDeadlineSeconds: 1800
       ttlSecondsAfterFinished: 3600
       template:
         metadata:
@@ -762,7 +762,7 @@ spec:
         interval: 1d
     spec:
       backoffLimit: 3
-      activeDeadlineSeconds: 2400
+      activeDeadlineSeconds: 3600
       ttlSecondsAfterFinished: 7200
       template:
         metadata:


### PR DESCRIPTION
## Summary

Fixes timeout issues causing DeadlineExceeded errors and JobAlreadyActive warnings for data-manager CronJobs.

## Changes

Updated `activeDeadlineSeconds` values in `k8s/klines-data-manager-production.yaml`:

- **m5**: 600s → 900s (15 minutes)
- **m15**: 600s → 1200s (20 minutes)  
- **m30**: 900s → 1200s (20 minutes)
- **h1**: 1200s → 1800s (30 minutes)
- **d1**: 2400s → 3600s (60 minutes)

## Acceptance Criteria

- [x] Identify all CronJobs with deadline issues
- [x] Increase `activeDeadlineSeconds` to recommended timeout values
- [x] Update CronJob manifests with new timeout values
- [ ] Deploy updated CronJobs (will be handled by CI/CD)
- [ ] Monitor for 48 hours to verify no deadline exceeded events
- [ ] Document recommended timeout values per timeframe

## Testing

- [x] Updated timeout values follow recommended guidelines from issue
- [ ] Will verify no DeadlineExceeded events after deployment

Closes #139