### PR TITLE
docs: add GitHub CLI profile configuration reference

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -21,6 +21,7 @@ Unlike the real-time socket-client, this service operates on a scheduled basis (
 
 - **Ecosystem Architecture**: See master § System Architecture Overview → Data Ingestion & Storage Layer
 - **Work Tracking**: See master § Centralized Work Tracking with GitHub Projects
+- **GitHub CLI Profile**: See master § Prerequisites & Installation → GitHub CLI Profile Configuration (CRITICAL: Always use `yurisa2` profile)
 - **NATS Topics**: Not applicable (this service writes directly to MySQL, not NATS)
 - **Database Architecture**: See master § Database Architecture (MySQL section)
 - **Deployment Patterns**: See master § Data Extractor Configuration


### PR DESCRIPTION
Adds reference to master cursorrules for GitHub CLI profile configuration requirement.

- References master cursorrules for GitHub CLI profile configuration
- Documents requirement to use yurisa2 profile for all GitHub operations
- Prevents permission errors when working with GitHub project board

This is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documentation-only update to clarify GitHub CLI usage.
> 
> - Updates `.cursorrules` to cross-reference master § Prerequisites & Installation → GitHub CLI Profile Configuration
> - Explicitly notes requirement to use the `yurisa2` GitHub CLI profile to avoid permission issues
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69cc05666f31f56eb60b4b36d8abc852e2a1ab04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->