### PR TITLE
fix(ci): enforce strict pipeline gate on required checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -193,33 +193,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test, test-quality, security-scan, documentation-standards]
     if: always()
-    permissions:
-      checks: write
-      statuses: write
     steps:
-      - name: Create pipeline status check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const conclusion = '${{ needs.lint.result }}' === 'success' &&
-                              '${{ needs.test.result }}' === 'success' &&
-                              '${{ needs.test-quality.result }}' === 'success' &&
-                              '${{ needs.security-scan.result }}' === 'success' &&
-                              '${{ needs.documentation-standards.result }}' === 'success'
-                              ? 'success' : 'failure';
+      - name: Validate upstream job results
+        run: |
+          echo "lint=${{ needs.lint.result }}"
+          echo "test=${{ needs.test.result }}"
+          echo "test-quality=${{ needs.test-quality.result }}"
+          echo "security-scan=${{ needs.security-scan.result }}"
+          echo "documentation-standards=${{ needs.documentation-standards.result }}"
 
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'pipeline',
-              head_sha: context.sha,
-              status: 'completed',
-              conclusion: conclusion,
-              output: {
-                title: conclusion === 'success' ? 'All checks passed' : 'Some checks failed',
-                summary: conclusion === 'success'
-                  ? 'All CI checks passed successfully.'
-                  : 'One or more CI checks failed. Please review the failed jobs.'
-              }
-            });
+          [[ "${{ needs.lint.result }}" == "success" ]]
+          [[ "${{ needs.test.result }}" == "success" ]]
+          [[ "${{ needs.test-quality.result }}" == "success" ]]
+          [[ "${{ needs.security-scan.result }}" == "success" ]]
+          [[ "${{ needs.documentation-standards.result }}" == "success" ]]
 # Trigger pipeline check


### PR DESCRIPTION
## Summary
- replace synthetic pipeline status creation with hard validation of upstream job results
- ensure  job fails when any required dependency job fails

## Why
Recent merges showed  reported success while child checks failed. This change makes  a true gate.

## Validation
- workflow logic now checks 
- branch protection still enforces required checks
