### PR TITLE
fix: make GitOps manifest update idempotent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,13 +109,14 @@ jobs:
       - name: Update data-extractor image tag in GitOps manifests
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
+          NAMESPACE="${{ secrets.DOCKERHUB_USERNAME }}"
           # Update the image tag and version labels in manifests robustly
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/image: .*\/petrosa-binance-data-extractor:.*/image: yurisa2\/petrosa-binance-data-extractor:$VERSION/g"
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/app.kubernetes.io\/version: .*/app.kubernetes.io\/version: $VERSION/g"
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/image: .*\/petrosa-binance-data-extractor:.*/image: ${NAMESPACE}\/petrosa-binance-data-extractor:${VERSION}/g"
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/version: .*/version: ${VERSION}/g"
           # Also handle any lingering placeholders
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g"
 
-          echo "Updated data-extractor image tag to $VERSION in petrosa_k8s/k8s/data-extractor/"
+          echo "Updated data-extractor image tag to ${VERSION} in petrosa_k8s/k8s/data-extractor/"
 
       - name: Commit and push to petrosa_k8s
         working-directory: petrosa_k8s


### PR DESCRIPTION
Targets image tags and version labels directly to allow reliable updates even without placeholders.