### PR TITLE
chore: standardize GitOps token flow across workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,35 +93,29 @@ jobs:
     needs: [build-and-push, create-release]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    outputs:
-      performed: ${{ steps.token-check.outputs.available }}
     steps:
-      - name: Validate GitOps token
-        id: token-check
-        run: |
-          if [ -z "${{ secrets.GITOPS_BOT_TOKEN }}" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GITOPS_BOT_TOKEN is not configured. Skipping GitOps update."
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Generate GitOps Bot Token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.GITOPS_APP_ID }}
+          private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
 
       - name: Checkout petrosa_k8s
-        if: steps.token-check.outputs.available == 'true'
         uses: actions/checkout@v4
         with:
           repository: PetroSa2/petrosa_k8s
           ref: main
-          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: petrosa_k8s
 
       - name: Rebase on main
-        if: steps.token-check.outputs.available == 'true'
         run: ./scripts/gitops-rebase-main.sh
         working-directory: petrosa_k8s
 
       - name: Update data-extractor image tag in GitOps manifests
-        if: steps.token-check.outputs.available == 'true'
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           NAMESPACE="${{ secrets.DOCKERHUB_USERNAME }}"
@@ -134,7 +128,6 @@ jobs:
           echo "Updated data-extractor image tag to ${VERSION} in petrosa_k8s/k8s/data-extractor/"
 
       - name: Commit and push to petrosa_k8s
-        if: steps.token-check.outputs.available == 'true'
         working-directory: petrosa_k8s
         run: |
           git config user.name "gitops-bot"
@@ -158,14 +151,9 @@ jobs:
         VERSION="${{ needs.create-release.outputs.version }}"
 
         if [ "${{ needs.gitops-update.result }}" == "success" ]; then
-          if [ "${{ needs.gitops-update.outputs.performed }}" == "true" ]; then
-            echo "✅ Build, Push, and GitOps Update successful!"
-            echo "📦 Version: ${VERSION}"
-            echo "🚀 Deployed via petrosa_k8s hub"
-          else
-            echo "ℹ️ Build and Push successful (GitOps update skipped: missing GITOPS_BOT_TOKEN)"
-            echo "📦 Version: ${VERSION}"
-          fi
+          echo "✅ Build, Push, and GitOps Update successful!"
+          echo "📦 Version: ${VERSION}"
+          echo "🚀 Deployed via petrosa_k8s hub"
         elif [ "${{ needs.gitops-update.result }}" == "skipped" ]; then
           echo "ℹ️ Build and Push successful (GitOps update skipped)"
           echo "📦 Version: ${VERSION}"

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -77,12 +77,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Generate GitOps Bot Token
+        uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.GITOPS_APP_ID }}
+          private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.GITOPS_APP_INSTALLATION_ID }}
+
       - name: Checkout petrosa_k8s
         uses: actions/checkout@v4
         with:
           repository: PetroSa2/petrosa_k8s
           ref: main
-          token: ${{ secrets.GITOPS_BOT_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: petrosa_k8s
 
       - name: Rebase on main
@@ -182,4 +191,3 @@ jobs:
 
           Please check the workflow logs for details.
           EOF
-


### PR DESCRIPTION
## Summary
- replace `GITOPS_BOT_TOKEN` usage with GitHub App token generation in `deploy.yml`
- replace `GITOPS_BOT_TOKEN` usage with GitHub App token generation in `manual-deploy.yml`
- align extractor workflow auth pattern with other services for `petrosa_k8s` checkout/push

## Details
This now matches the existing pattern used by other services:
- `tibdex/github-app-token@v2`
- secrets: `GITOPS_APP_ID`, `GITOPS_APP_PRIVATE_KEY`, `GITOPS_APP_INSTALLATION_ID`
- checkout uses `${{ steps.generate-token.outputs.token }}`
