### PR TITLE
fix: restore klines extractor Data Manager query/insert compatibility

### DIFF
--- a/adapters/data_manager_adapter.py
+++ b/adapters/data_manager_adapter.py
@@ -7,6 +7,7 @@ petrosa-data-manager API for data persistence.
 
 import asyncio
 from datetime import datetime
+from inspect import isawaitable
 from typing import Any
 
 import constants
@@ -167,12 +168,13 @@ class DataManagerAdapter:
 
             else:
                 # Generic insert for other collection types
-                result = await self._client._client.insert(
+                result = self._client._client.insert(
                     database=self.database,
                     collection=collection_name,
-                    data=data_dicts,
-                    validate=True,
+                    records=data_dicts,
                 )
+                if isawaitable(result):
+                    result = await result
 
             written_count = result.get("inserted_count", 0)
             logger.info(f"Wrote {written_count} records to {collection_name}")
@@ -209,15 +211,19 @@ class DataManagerAdapter:
                 filter_dict["symbol"] = symbol
 
             # Query for latest records
-            result = await self._client._client.query(
+            result = self._client._client.query(
                 database=self.database,
                 collection=collection_name,
-                filter=filter_dict,
-                sort={"close_time": -1}
-                if "klines" in collection_name
-                else {"timestamp": -1},
-                limit=limit,
+                params={
+                    "filter": filter_dict,
+                    "sort": {"close_time": -1}
+                    if "klines" in collection_name
+                    else {"timestamp": -1},
+                    "limit": limit,
+                },
             )
+            if isawaitable(result):
+                result = await result
 
             return result.get("data", [])
 

--- a/clients/data_manager_client.py
+++ b/clients/data_manager_client.py
@@ -6,6 +6,7 @@ with the petrosa-data-manager API for data persistence.
 """
 
 import os
+from inspect import isawaitable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -213,12 +214,13 @@ class DataManagerClient:
                 f"Inserting {len(klines_data)} klines for {symbol} ({interval})"
             )
 
-            result = await self._client.insert(
+            result = self._client.insert(
                 database=database,
                 collection=collection_name,
-                data=klines_data,
-                validate=True,  # Enable schema validation
+                records=klines_data,
             )
+            if isawaitable(result):
+                result = await result
 
             logger.info(
                 f"Successfully inserted {result.get('inserted_count', 0)} klines for {symbol}"
@@ -264,12 +266,13 @@ class DataManagerClient:
         try:
             logger.info(f"Inserting {len(trades_data)} trades for {symbol}")
 
-            result = await self._client.insert(
+            result = self._client.insert(
                 database=database,
                 collection=collection_name,
-                data=trades_data,
-                validate=True,
+                records=trades_data,
             )
+            if isawaitable(result):
+                result = await result
 
             logger.info(
                 f"Successfully inserted {result.get('inserted_count', 0)} trades for {symbol}"
@@ -306,12 +309,13 @@ class DataManagerClient:
         try:
             logger.info(f"Inserting {len(funding_data)} funding rates for {symbol}")
 
-            result = await self._client.insert(
+            result = self._client.insert(
                 database=database,
                 collection=collection_name,
-                data=funding_data,
-                validate=True,
+                records=funding_data,
             )
+            if isawaitable(result):
+                result = await result
 
             logger.info(
                 f"Successfully inserted {result.get('inserted_count', 0)} funding rates for {symbol}"
@@ -343,13 +347,17 @@ class DataManagerClient:
 
         try:
             # Query for the latest record
-            result = await self._client.query(
+            result = self._client.query(
                 database=database,
                 collection=collection_name,
-                filter={"symbol": symbol},
-                sort={"close_time": -1},
-                limit=1,
+                params={
+                    "filter": {"symbol": symbol},
+                    "sort": {"close_time": -1},
+                    "limit": 1,
+                },
             )
+            if isawaitable(result):
+                result = await result
 
             if result.get("data") and len(result["data"]) > 0:
                 latest_record = result["data"][0]
@@ -398,19 +406,23 @@ class DataManagerClient:
 
         try:
             # Query for existing timestamps in the range
-            result = await self._client.query(
+            result = self._client.query(
                 database=database,
                 collection=collection_name,
-                filter={
-                    "symbol": symbol,
-                    "close_time": {
-                        "$gte": start_time.isoformat(),
-                        "$lte": end_time.isoformat(),
+                params={
+                    "filter": {
+                        "symbol": symbol,
+                        "close_time": {
+                            "$gte": start_time.isoformat(),
+                            "$lte": end_time.isoformat(),
+                        },
                     },
+                    "sort": {"close_time": 1},
+                    "fields": ["close_time"],
                 },
-                sort={"close_time": 1},
-                fields=["close_time"],
             )
+            if isawaitable(result):
+                result = await result
 
             # Extract timestamps
             existing_timestamps = []


### PR DESCRIPTION
## Summary
- fix Data Manager client calls to use current base API contract (records for insert, params for query)
- remove invalid await on synchronous base client calls and add awaitable fallback for test/mocking compatibility
- align low-level adapter generic insert/query paths with the same API contract

## Validation
- python3 -m py_compile clients/data_manager_client.py adapters/data_manager_adapter.py
- Note: pytest did not emit usable output in this shell runner; compile and static verification passed.

## Production impact
This addresses the active klines-extractor errors:
- BaseDataManagerClient.insert() got an unexpected keyword argument data
- BaseDataManagerClient.query() got an unexpected keyword argument filter