### PR TITLE
ci: use ubuntu-latest for Docker build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   build-and-push:
     name: Build & Push
     needs: create-release
-    runs-on: petrosa-org-runners
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Docker build/push requires Docker socket which is not available in self-hosted runners. Use ubuntu-latest (GitHub-hosted) for build-and-push job only.