### PR TITLE
chore: robust gitops update regex

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,11 +119,13 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           # Update the image tag in manifests robustly (preserves registry/repo, only updates tag)
-          # We search for both petrosa-binance-data-extractor and petrosa-binance-extractor (some old cronjobs use the latter)
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*[^[:space:]]*/petrosa-binance-(data-)?extractor):[^[:space:]]*|\1:$VERSION|g"
+          # Handles both qualified (e.g., repo/petrosa-binance-extractor:tag) and unqualified (petrosa-binance-extractor:tag) image names
+          # We search for both petrosa-binance-data-extractor and petrosa-binance-extractor
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-(data-)?extractor):[^[:space:]]*|\1\2\3:$VERSION|g"
           
           # Update version labels specifically (targets common label patterns)
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s/(version|app.kubernetes.io\/version):.*/\1: $VERSION/g"
+          # Anchored to start of line to prevent over-matching apiVersion
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s/^([[:space:]]*(version|app\.kubernetes\.io\/version)):.*/\1: $VERSION/g"
           
           # Also handle any lingering placeholders for backward compatibility
           find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -i "s/VERSION_PLACEHOLDER/$VERSION/g"


### PR DESCRIPTION
Updates deploy workflow to use more robust regex for GitOps manifest updates.