### PR TITLE
Standardize Package Discovery and Add petrosa-otel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",
     "prometheus-client>=0.19.0",
+    "petrosa-otel[mysql,mongodb]>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Merging improvements from sync/pre-transition-sync and standardizing pyproject.toml package discovery and dependencies.