### PR TITLE
fix(k8s): remove unsupported --incremental from mongodb klines cronjobs

### DIFF
--- a/k8s/klines-mongodb-production.yaml
+++ b/k8s/klines-mongodb-production.yaml
@@ -44,7 +44,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=5m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -232,7 +231,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=15m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -420,7 +418,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=30m
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -608,7 +605,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=1h
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:
@@ -796,7 +792,6 @@ spec:
             - jobs.extract_klines_data_manager
             args:
             - --period=1d
-            - --incremental
             env:
             - name: BINANCE_API_KEY
               valueFrom:


### PR DESCRIPTION
## Summary

Remove unsupported `--incremental` CLI argument from mongodb production klines CronJobs.

`jobs.extract_klines_data_manager` does not define `--incremental`, causing job startup failures:
- `extract_klines_data_manager.py: error: unrecognized arguments: --incremental`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation update
- [x] Infrastructure change

## Testing

- Confirmed `jobs/extract_klines_data_manager.py` argparse does not include `--incremental`.
- Manual runtime validation in k8s:
  - Job: `manual-m5-mongo-verify-1772937765`
  - Result: Complete
  - `Symbols failed: 0`
  - `Total records fetched: 2880`
  - `Total records written: 2880`
  - No `unrecognized arguments: --incremental` errors.
- `kubectl apply --dry-run=client -f k8s/klines-mongodb-production.yaml` passes.

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation as needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

Fixes production cronjob arg mismatch for mongodb klines extractor.

## Additional Context

Scope is intentionally minimal: remove `--incremental` from 5m/15m/30m/1h/1d blocks in `k8s/klines-mongodb-production.yaml`.
