### PR TITLE
fix: defer copilot review gate until after CI checks (#398)

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,13 +1,15 @@
+# yamllint disable rule:line-length rule:truthy rule:document-start
 # TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
-# before requiring the `copilot-review / copilot-review` status check on `main`.
+# before requiring the `copilot-review` status check on `main`.
 #
 # Enforces merge gating: Copilot must have reviewed the PR (any commit) and
 # all non-outdated Copilot-started review threads must be resolved.
 #
 # Design: one Copilot review per PR is the correct standard (issue #380).
-# Re-review via API is a no-op — the thread-resolution check is the real quality gate.
+# Re-review via API is a no-op — the GitHub UI "Re-request review" button is the
+# only working mechanism. The thread-resolution check is the real quality gate.
 #
-# Branch protection must require the check name: copilot-review / copilot-review
+# Branch protection must require the check name: copilot-review
 # (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
 #
 # Related: petrosa_k8s Issue #354 (rollout), Issue #330 (original enforcement design)
@@ -15,9 +17,6 @@
 name: copilot-review
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
@@ -35,6 +34,9 @@ concurrency:
 jobs:
   copilot-review:
     name: copilot-review
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: petrosa-org-runners
     permissions:
       contents: read
@@ -53,9 +55,6 @@ jobs:
             const repo = context.repo.repo;
 
             async function resolvePullRequest() {
-              if (context.eventName === 'pull_request') {
-                return context.payload.pull_request;
-              }
               if (context.eventName === 'pull_request_review') {
                 return context.payload.pull_request;
               }

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,5 +1,9 @@
+# yamllint disable rule:line-length rule:truthy rule:document-start
 # Defers GitHub Copilot review until CI Checks complete successfully.
 # Replaces the pull_request trigger with workflow_run to enforce post-CI ordering.
+#
+# Merge blocking is handled separately by `copilot-review-gate.yml`, which must pass
+# for the required check `copilot-review` (see docs/COPILOT_REVIEW_ENFORCEMENT.md).
 #
 # Fix for Issue #371: workflow_run.pull_requests[] is always empty in GitHub's event
 # payload even for same-repo PRs. PR resolution is done via the REST API using
@@ -23,9 +27,9 @@ on:
 
 jobs:
   request-copilot-review:
-    # workflow_run.pull_requests[] is always empty (GitHub bug/limitation); the
-    # fork check and PR resolution happen inside the script via the REST API.
-    # head_repository guard ensures we only act on same-repo workflow_run events.
+    # `if` head_repository guard below. For workflow_dispatch, the fork guard
+    # runs inside the script. PR resolution happens via the REST API using
+    # head_sha + head_branch (workflow_run.pull_requests[] is unreliable).
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION
Implements #398 by removing the pull_request trigger from copilot-review-gate and adding workflow_dispatch to request-copilot-review.