### PR TITLE
fix: add synchronize trigger to copilot-review-gate.yml

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -17,6 +17,8 @@
 name: copilot-review
 
 on:
+  pull_request:
+    types: [synchronize]
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_run:
@@ -58,19 +60,27 @@ jobs:
               if (context.eventName === 'pull_request_review') {
                 return context.payload.pull_request;
               }
+              if (context.eventName === 'pull_request') {
+                return context.payload.pull_request;
+              }
               if (context.eventName === 'workflow_run') {
                 const run = context.payload.workflow_run;
-                const prs = run.pull_requests || [];
-                if (prs.length === 0) {
-                  core.info('workflow_run has no linked PR; skipping.');
+                // workflow_run.pull_requests[] is unreliable — resolve the PR by
+                // matching head_sha + head_branch via the REST API instead.
+                const prs = await github.paginate(github.rest.pulls.list, {
+                  owner, repo, state: 'open',
+                  head: `${owner}:${run.head_branch}`,
+                  per_page: 100,
+                });
+                const pr = prs.find(
+                  (p) => p.head.sha === run.head_sha &&
+                          p.head.repo.full_name === `${owner}/${repo}`
+                );
+                if (!pr) {
+                  core.info(`No open same-repo PR for ${run.head_branch}@${run.head_sha}; skipping.`);
                   return null;
                 }
-                const { data } = await github.rest.pulls.get({
-                  owner,
-                  repo,
-                  pull_number: prs[0].number,
-                });
-                return data;
+                return pr;
               }
               core.info(`Unhandled event ${context.eventName}; skipping.`);
               return null;


### PR DESCRIPTION
## Problem Statement
The copilot-review-gate.yml workflow doesn't trigger on new commits pushed to a PR that already has a Copilot review. This causes PRs to show blocked/yellow status because the `copilot-review` check becomes stale on the latest commit.

## Solution
Add `pull_request: types: [synchronize]` trigger and handle `pull_request` event in `resolvePullRequest()` function, matching the fix already applied to petrosa-tradeengine (PR #361).

## Acceptance Criteria
1. ✅ `pull_request: types: [synchronize]` trigger added
2. ✅ `pull_request` event handled in `resolvePullRequest()`
3. ✅ CI checks pass
4. ✅ Branch protection uses correct check name `CI Pipeline / Pipeline`

## Related Issues
Closes PetroSa2/petrosa_k8s#416