### PR TITLE
chore: bump version to deploy petrosa-otel 1.0.5 fix (fresh)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "petrosa-binance-data-extractor"
-version = "1.1.33"
+version = "1.1.34"
 description = "Binance market data extraction service"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "petrosa-binance-data-extractor"
-version = "1.1.32"
+version = "1.1.33"
 description = "Binance market data extraction service"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Replacing #247 which got stuck in branch protection state.