### PR TITLE
fix: #498 - remove dead (data-)? alternation from deploy.yml image sed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,9 +121,8 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-push.outputs.version }}"
           # Update the image tag in manifests robustly (preserves registry/repo, only updates tag)
-          # Handles both qualified (e.g., repo/petrosa-binance-extractor:tag) and unqualified (petrosa-binance-extractor:tag) image names
-          # We search for both petrosa-binance-data-extractor and petrosa-binance-extractor
-          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-(data-)?extractor):[^[:space:]]*|\1\2\3:$VERSION|g"
+          # Handles both qualified (e.g., repo/petrosa-binance-data-extractor:tag) and unqualified (petrosa-binance-data-extractor:tag) image names
+          find petrosa_k8s/k8s/data-extractor -type f \( -name "*.yaml" -o -name "*.yml" \) -print0 | xargs -0 -r sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-data-extractor):[^[:space:]]*|\1\2\3:$VERSION|g"
 
           # Update version labels specifically (targets common label patterns)
           # Anchored to start of line to prevent over-matching apiVersion


### PR DESCRIPTION
## Summary

Implements one of three acceptance criteria from [petrosa_k8s#498](https://github.com/PetroSa2/petrosa_k8s/issues/498).

The previous `image:` sed carried a `(data-)?` alternation that was added for a planned rename to `petrosa-binance-extractor`. The rename never happened — `grep -rE "petrosa-binance-(data-)?extractor" petrosa_k8s/k8s/data-extractor/` shows zero occurrences of `petrosa-binance-extractor` (without `data-`). Simplify to the canonical Type A pattern used across services.

### Before
```bash
sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-(data-)?extractor):[^[:space:]]*|\1\2\3:$VERSION|g"
```

### After (canonical)
```bash
sed -E -i "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-data-extractor):[^[:space:]]*|\1\2\3:$VERSION|g"
```

Also drops the now-incorrect comment line that mentions both forms.

## Regression Risk

**Low.** The dead alternation never matched anything in the current GitOps tree. Match behavior is identical on every existing manifest. Manifest content unchanged.

## Verification

- `sed -E "s|(image:[[:space:]]*)([^[:space:]]*/)?(petrosa-binance-data-extractor):[^[:space:]]*|\1\2\3:v9.9.9|g"` against `yurisa2/petrosa-binance-data-extractor:v0.0.1` and `petrosa-binance-data-extractor:tag` — both rewritten correctly.
- actionlint shows no new findings on the changed lines (only pre-existing runner-label and SC2086 noise on unrelated lines).

## Test Plan

- [ ] CI passes on this PR.
- [ ] On next data-extractor deploy run, confirm the manifest in `petrosa_k8s/k8s/data-extractor/` receives the expected tag.