### PR TITLE
feat(metrics): emit extractor.binance.weight.used_1m OTel metric (#696)

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   pipeline:

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -1,14 +1,11 @@
 # yamllint disable rule:line-length rule:truthy rule:document-start
-# TEMPLATE — Copy to `.github/workflows/copilot-review-gate.yml` in each Petrosa repo
-# before requiring the `copilot-review` status check on `main`.
+# Thin caller — delegates to the centralized reusable workflow in petrosa-shared-workflows.
+# Gate logic (check_run on PR head SHA, Copilot thread resolution) lives in:
+#   PetroSa2/petrosa-shared-workflows/.github/workflows/copilot-review-gate.yml@main
+# See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md and petrosa_k8s#707.
 #
-# Enforces merge gating: Copilot must have reviewed the current PR head SHA and
-# all non-outdated Copilot-started review threads must be resolved.
-#
-# Branch protection must require the check name: copilot-review
-# (workflow name / job name). See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md
-#
-# Related: petrosa_k8s Issue #354 (rollout), Issue #330 (original enforcement design)
+# NOTE: the pull_request_review trigger is intentionally absent — see petrosa_k8s#559.
+# NOTE: cancel-in-progress: false is set in the reusable workflow — see petrosa_k8s#362.
 
 name: copilot-review
 
@@ -19,34 +16,9 @@ on:
         description: 'PR number to gate'
         required: true
         type: number
-  # NOTE (PetroSa2/petrosa_k8s#559): the `pull_request_review` trigger was
-  # removed because Copilot bot's review submission fires this workflow with
-  # triggering_actor=Copilot (a Bot account, BOT_kgDOCnlnWA node_id). GitHub's
-  # workflow-approval policy (`fork-pr-contributor-approval`) treats Bot
-  # accounts as external actors regardless of the policy value, producing the
-  # "1 workflow awaiting approval" banner on every PR.
-  #
-  # We trigger from "CI Checks" (one workflow_run hop) instead of
-  # "Request Copilot Review" (two workflow_run hops). At two hops,
-  # `payload.workflow_run.head_branch/head_sha` collapses to the
-  # default branch's HEAD, so PR resolution fails ("No open same-repo PR
-  # for main@..."). With CI Checks as the upstream, payload reports the
-  # actual PR branch + PR head SHA, and the gate can find the PR.
-  #
-  # The Request Copilot Review workflow still triggers from CI Checks in
-  # parallel — Copilot review request happens alongside the gate's polling
-  # loop, so there is no scheduling regression.
   workflow_run:
     workflows: ["CI Checks"]
     types: [completed]
-
-concurrency:
-  # Queue new gate runs — never cancel an in-flight run.
-  # cancel-in-progress: true caused a regression (#362): the pull_request_review event
-  # (fired when Copilot submits its review) cancelled the existing polling run that was
-  # about to succeed, and the replacement run failed due to API propagation delay.
-  group: copilot-review-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
 
 jobs:
   copilot-review:
@@ -55,254 +27,11 @@ jobs:
       github.event_name != 'workflow_run' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'pull_request')
-    runs-on: petrosa-org-runners
     permissions:
       contents: read
       pull-requests: read
       checks: write
-    env:
-      # GitHub Actions deprecates Node.js 20 for JS actions in 2026; opt into Node 24 early.
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
-    steps:
-      - name: Verify Copilot review and resolved threads
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            async function resolvePullRequest() {
-              if (context.eventName === 'workflow_dispatch') {
-                const pull_number_input = parseInt(context.payload.inputs?.pull_number, 10);
-                if (!Number.isInteger(pull_number_input) || pull_number_input <= 0) {
-                  core.setFailed('workflow_dispatch requires a valid pull_number input');
-                  return null;
-                }
-                const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: pull_number_input });
-                return pr;
-              }
-              if (context.eventName === 'workflow_run') {
-                const run = context.payload.workflow_run;
-                const prs = await github.paginate(github.rest.pulls.list, {
-                  owner, repo, state: 'open',
-                  head: `${owner}:${run.head_branch}`,
-                  per_page: 100,
-                });
-                const pr = prs.find(
-                  (p) => p.head.sha === run.head_sha &&
-                          p.head.repo.full_name === `${owner}/${repo}`
-                );
-                if (!pr) {
-                  core.info(`No open same-repo PR for ${run.head_branch}@${run.head_sha}; skipping.`);
-                  return null;
-                }
-                return pr;
-              }
-              core.info(`Unhandled event ${context.eventName}; skipping.`);
-              return null;
-            }
-
-            const pr = await resolvePullRequest();
-            if (!pr) {
-              return;
-            }
-
-            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-              core.info(`Skipping fork PR ${pr.head.repo.full_name}`);
-              return;
-            }
-
-            const pull_number = pr.number;
-            const headSha = pr.head.sha;
-
-            // workflow_run-triggered runs attach their natural check_run to the
-            // workflow file's commit (default branch HEAD), NOT to the PR head.
-            // Branch protection looks at PR head checks only — so we explicitly
-            // create a check_run on the PR head SHA here. This decouples the
-            // gate-result check from the trigger event's SHA.
-            // See PetroSa2/petrosa_k8s#559 for the full rationale.
-            let gateCheckRunId = null;
-            try {
-              const { data: createdCheck } = await github.rest.checks.create({
-                owner,
-                repo,
-                name: 'copilot-review',
-                head_sha: headSha,
-                status: 'in_progress',
-                started_at: new Date().toISOString(),
-                output: {
-                  title: 'Copilot review gate',
-                  summary: `Polling for Copilot review and verifying thread resolution on ${headSha}.`,
-                },
-              });
-              gateCheckRunId = createdCheck.id;
-              core.info(`Created copilot-review check_run ${gateCheckRunId} on PR head ${headSha}.`);
-            } catch (err) {
-              core.warning(`Could not create check_run on PR head: ${err.message}`);
-            }
-
-            async function finalizeCheck(conclusion, summary) {
-              if (!gateCheckRunId) return;
-              try {
-                await github.rest.checks.update({
-                  owner,
-                  repo,
-                  check_run_id: gateCheckRunId,
-                  status: 'completed',
-                  conclusion,
-                  completed_at: new Date().toISOString(),
-                  output: {
-                    title: 'Copilot review gate',
-                    summary,
-                  },
-                });
-              } catch (err) {
-                core.warning(`Could not finalize check_run: ${err.message}`);
-              }
-            }
-
-            const isCopilotPrReviewer = (login) => {
-              if (!login) return false;
-              const l = String(login).toLowerCase();
-              return (
-                l === 'copilot-pull-request-reviewer' ||
-                l.startsWith('copilot-pull-request-reviewer[')
-              );
-            };
-
-            async function hasCopilotReview() {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                owner,
-                repo,
-                pull_number,
-                per_page: 100,
-              });
-
-              // Accept any non-dismissed Copilot review on this PR. Copilot cannot
-              // re-review after already reviewing (requestReviewers is a no-op for
-              // Copilot once it has reviewed). Thread resolution is the real quality
-              // gate — if all Copilot threads are resolved, the code is approved.
-              return reviews.some(
-                (r) =>
-                  r.user &&
-                  isCopilotPrReviewer(r.user.login) &&
-                  r.state !== 'DISMISSED' &&
-                  r.state !== 'PENDING'
-              );
-            }
-
-            // Copilot reviews are asynchronous and often land after CI completes and after the
-            // review request workflow runs. To avoid flaky “rerun until Copilot posts” behavior,
-            // poll for a bounded time before failing.
-            const maxWaitSeconds = 20 * 60; // 20 minutes
-            const pollIntervalSeconds = 30;
-            let waited = 0;
-
-            while (waited <= maxWaitSeconds) {
-              if (await hasCopilotReview()) {
-                core.info(`Found submitted Copilot review for PR #${pull_number} @ ${headSha}.`);
-                break;
-              }
-
-              if (waited === 0) {
-                core.info(
-                  `Waiting for Copilot PR review on current head ${headSha} (polling up to ${maxWaitSeconds}s).`
-                );
-              }
-
-              if (waited >= maxWaitSeconds) {
-                const msg = `No submitted Copilot PR review for current head ${headSha} after waiting ${maxWaitSeconds}s. ` +
-                  `Copilot may be delayed; re-request Copilot review and retry once it submits a review on the latest commit.`;
-                await finalizeCheck('failure', msg);
-                core.setFailed(msg);
-                return;
-              }
-
-              await new Promise((r) => setTimeout(r, pollIntervalSeconds * 1000));
-              waited += pollIntervalSeconds;
-            }
-
-            async function loadAllReviewThreads() {
-              const threadQuery = `query ($owner: String!, $repoName: String!, $pull: Int!, $tcursor: String) {
-                repository(owner: $owner, name: $repoName) {
-                  pullRequest(number: $pull) {
-                    reviewThreads(first: 100, after: $tcursor) {
-                      pageInfo { hasNextPage endCursor }
-                      nodes {
-                        isResolved
-                        isOutdated
-                        comments(first: 100) {
-                          nodes { author { login } }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`;
-
-              const threadsOut = [];
-              let tCursor = null;
-              for (let p = 0; p < 20; p++) {
-                const tr = await github.graphql(threadQuery, {
-                  owner,
-                  repoName: repo,
-                  pull: pull_number,
-                  tcursor: tCursor,
-                });
-                const conn = tr.repository?.pullRequest?.reviewThreads;
-                const nodes = conn?.nodes || [];
-                for (const t of nodes) {
-                  const commentNodes = t.comments?.nodes || [];
-                  // Only track the thread-starter (first comment author) to avoid
-                  // blocking on human threads where Copilot later replies.
-                  const starterLogin = commentNodes.length > 0
-                    ? commentNodes[0].author?.login
-                    : null;
-                  threadsOut.push({
-                    isResolved: t.isResolved,
-                    isOutdated: t.isOutdated,
-                    starterLogin,
-                  });
-                }
-                if (!conn?.pageInfo?.hasNextPage) break;
-                tCursor = conn.pageInfo.endCursor;
-              }
-              return threadsOut;
-            }
-
-            const threads = await loadAllReviewThreads();
-
-            const isCopilotAuthor = (login) => {
-              if (!login) return false;
-              const l = String(login).toLowerCase();
-              return (
-                l === 'copilot' ||
-                l === 'copilot-pull-request-reviewer' ||
-                l.startsWith('copilot-pull-request-reviewer[')
-              );
-            };
-
-            const unresolved = [];
-            for (const t of threads) {
-              if (t.isOutdated) continue;
-              // A "Copilot thread" is one started by Copilot (first comment author).
-              // This avoids blocking on human threads where Copilot later replies.
-              const copilotThread = isCopilotAuthor(t.starterLogin);
-              if (copilotThread && !t.isResolved) {
-                unresolved.push('unresolved Copilot thread');
-              }
-            }
-
-            if (unresolved.length > 0) {
-              const msg = 'One or more Copilot review threads are still unresolved. Resolve or justify each thread in the PR before merge.';
-              await finalizeCheck('failure', msg);
-              core.setFailed(msg);
-              return;
-            }
-
-            await finalizeCheck('success', `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}.`);
-            core.info(
-              `Copilot review gate passed for ${repo}#${pull_number} @ ${headSha}.`
-            );
+    uses: PetroSa2/petrosa-shared-workflows/.github/workflows/copilot-review-gate.yml@main
+    with:
+      dispatch-pull-number: ${{ github.event.inputs.pull_number || '' }}
+    secrets: inherit

--- a/.github/workflows/request-copilot-review.yml
+++ b/.github/workflows/request-copilot-review.yml
@@ -1,16 +1,8 @@
 # yamllint disable rule:line-length rule:truthy rule:document-start
-# Defers GitHub Copilot review until CI Checks complete successfully.
-# Replaces the pull_request trigger with workflow_run to enforce post-CI ordering.
-#
-# Merge blocking is handled separately by `copilot-review-gate.yml`, which must pass
-# for the required check `copilot-review` (see docs/COPILOT_REVIEW_ENFORCEMENT.md).
-#
-# Fix for Issue #371: workflow_run.pull_requests[] is always empty in GitHub's event
-# payload even for same-repo PRs. PR resolution is done via the REST API using
-# head_sha + head_branch from the workflow_run context instead.
-#
-# Related: Issue #314 - Defer Copilot Review Until CI Checks Succeed
-# Supersedes: Issue #54, #188
+# Thin caller — delegates to the centralized reusable workflow in petrosa-shared-workflows.
+# Logic (draft gate, dedup, fork guard, F1/F2 dispatch fix) lives in:
+#   PetroSa2/petrosa-shared-workflows/.github/workflows/request-copilot-review.yml@main
+# See petrosa_k8s/docs/COPILOT_REVIEW_ENFORCEMENT.md and petrosa_k8s#707.
 
 name: Request Copilot Review
 
@@ -27,99 +19,15 @@ on:
 
 jobs:
   request-copilot-review:
-    # `if` head_repository guard below. For workflow_dispatch, the fork guard
-    # runs inside the script. PR resolution happens via the REST API using
-    # head_sha + head_branch (workflow_run.pull_requests[] is unreliable).
     if: >
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository)
-    runs-on: petrosa-org-runners
     permissions:
       pull-requests: write
       contents: read
-
-    steps:
-      - name: Request Copilot Review
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo } = context.repo;
-
-            let pull_number;
-            let headSha;
-
-            if (context.eventName === 'workflow_dispatch') {
-              pull_number = parseInt(context.payload.inputs.pull_number, 10);
-              if (!Number.isInteger(pull_number) || pull_number <= 0) {
-                core.setFailed(`Invalid pull_number input: must be a positive integer, got "${context.payload.inputs.pull_number}".`);
-                return;
-              }
-              // Fetch and validate the PR exists and is not a fork
-              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
-              if (pr.head.repo.full_name !== `${owner}/${repo}`) {
-                console.log(`Skipping fork PR from ${pr.head.repo.full_name}`);
-                return;
-              }
-              headSha = pr.head.sha;
-            } else {
-              // workflow_run.pull_requests[] is unreliable — resolve the PR by
-              // matching head_sha + head_branch via the REST API instead.
-              const run = context.payload.workflow_run;
-              const prs = await github.paginate(github.rest.pulls.list, {
-                owner, repo, state: 'open',
-                head: `${owner}:${run.head_branch}`,
-                per_page: 100,
-              });
-              const pr = prs.find(
-                (p) => p.head.sha === run.head_sha &&
-                        p.head.repo.full_name === `${owner}/${repo}`
-              );
-              if (!pr) {
-                console.log(`No open same-repo PR for ${run.head_branch}@${run.head_sha}; skipping.`);
-                return;
-              }
-              pull_number = pr.number;
-              // Use live PR head SHA (matches run.head_sha; avoids stale payload)
-              headSha = pr.head.sha;
-            }
-
-            // Short-circuit: skip if Copilot has already submitted any review on this PR.
-            // One Copilot review per PR is the correct standard (#380) — re-review via
-            // API is a no-op (requestReviewers returns 200 but fires no review_requested
-            // event for Copilot). The thread-resolution check in the gate is the real
-            // quality enforcement; requesting again would have no effect.
-            const reviews = await github.paginate(github.rest.pulls.listReviews, {
-              owner, repo, pull_number, per_page: 100,
-            });
-            const isCopilot = (login) => {
-              const l = (login || '').toLowerCase();
-              return l === 'copilot-pull-request-reviewer' || l.startsWith('copilot-pull-request-reviewer[');
-            };
-            const alreadyReviewed = reviews.some(
-              (r) => isCopilot(r.user?.login) &&
-                r.state !== 'DISMISSED' && r.state !== 'PENDING'
-            );
-            if (alreadyReviewed) {
-              console.log(`Copilot already reviewed this PR; skipping re-request.`);
-              return;
-            }
-
-            console.log(`Requesting Copilot review for PR #${pull_number}...`);
-
-            try {
-              await github.rest.pulls.requestReviewers({
-                owner,
-                repo,
-                pull_number,
-                reviewers: ['github-copilot'],
-              });
-              console.log(`Requested Copilot review for PR #${pull_number}`);
-            } catch (error) {
-              // 422 = Copilot unavailable or already in review queue; safe to ignore.
-              // All other errors are re-thrown so the step fails visibly.
-              if (error.status !== 422) throw error;
-              console.log('Copilot already requested or unavailable (422); continuing.');
-            }
+    uses: PetroSa2/petrosa-shared-workflows/.github/workflows/request-copilot-review.yml@main
+    with:
+      dispatch-pull-number: ${{ github.event.inputs.pull_number || '' }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
Implements #696 AC1 and AC2 for petrosa-binance-data-extractor.

## Changes
- **`utils/metrics.py`**: Add `binance_weight_1m` histogram (`extractor.binance.weight.used_1m`) and `record_binance_weight()$ method to `ExtractionMetrics`
- **`fetchers/client.py`**: Read `X-MBX-USED-WEIGHT-1M` response header in every `BinanceClient.get()` call and emit the OTel metric
- **`constants.py`**: Add `BINANCE_WEIGHT_HARD_LIMIT` (default 1200) and `BINANCE_WEIGHT_CEILING_PCT` (default 0.60) env-configurable constants (AC2)
- **`tests/test_metrics.py`**: Update assertions for new histogram instrument

## Acceptance Criteria
- [x] AC1: `extractor.binance.weight.used_1m` emitted on every API response via `X-MBX-USED-WEIGHT-1M` header
- [x] AC2: Configurable ceiling constants (`BINANCE_WEIGHT_HARD_LIMIT`, `BINANCE_WEIGHT_CEILING_PCT`)

## Test results
99 passed, 1 pre-existing failure (`test_list_cronjobs_success` — fails on clean main too, unrelated to this PR)