### PR TITLE
feat: data-extractor evaluator producer — publish evaluator.data-extractor.verdict (#259)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -58,6 +58,24 @@ async def lifespan(app: FastAPI):
 
     logger.info("Starting Data Extractor Configuration API")
 
+    # Start health evaluator (publishes evaluator.data-extractor.verdict).
+    # Read-only — subscribes to binance.extraction.> completion events.
+    # Optional: skipped if petrosa-otel lacks the evaluators framework or
+    # if NATS is disabled. Stored on app.state for shutdown.
+    app.state.health_evaluator = None
+    try:
+        from evaluators import build_data_extractor_health_evaluator
+
+        _evaluator = build_data_extractor_health_evaluator(
+            nats_servers=os.getenv("NATS_URL") or os.getenv("NATS_SERVERS")
+        )
+        if _evaluator is not None:
+            await _evaluator.start()
+            app.state.health_evaluator = _evaluator
+            logger.info("✅ Data-extractor health evaluator started")
+    except ImportError:
+        logger.warning("petrosa_otel.evaluators unavailable; health evaluator disabled")
+
     # 3. Attach OTel logging handler LAST (after logging is configured)
     if (
         os.getenv("ENABLE_OTEL", "true").lower() in ("true", "1", "yes")
@@ -76,6 +94,12 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown
     logger.info("Shutting down Data Extractor Configuration API")
+    if getattr(app.state, "health_evaluator", None) is not None:
+        try:
+            await app.state.health_evaluator.stop()
+            logger.info("✅ Data-extractor health evaluator stopped")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"Health evaluator stop error: {exc}")
 
 
 def create_app() -> FastAPI:

--- a/evaluators/__init__.py
+++ b/evaluators/__init__.py
@@ -1,0 +1,23 @@
+"""data-extractor subsystem evaluator (P2.7, petrosa_k8s#697 AC2 / #259).
+
+Adopts the shared `petrosa_otel.evaluators` framework (P2.1) so the
+data-extractor service publishes a structured health verdict on
+``evaluator.data-extractor.verdict``, closing the last of the five
+"silent service" gaps that keep FR17 / FR23 / FR32 at YELLOW.
+
+The evaluator lives in the long-lived API pod (api/main.py FastAPI lifespan)
+rather than in the short-lived CronJob entrypoints — it subscribes to the
+existing ``binance.extraction.>`` NATS completion stream so the framework's
+hysteresis / cadence model (which assumes a long-lived process) works as
+designed. See the module docstring in ``health_evaluator.py`` for details.
+"""
+
+from evaluators.health_evaluator import (
+    DataExtractorHealthEvaluator,
+    build_data_extractor_health_evaluator,
+)
+
+__all__ = [
+    "DataExtractorHealthEvaluator",
+    "build_data_extractor_health_evaluator",
+]

--- a/evaluators/health_evaluator.py
+++ b/evaluators/health_evaluator.py
@@ -1,0 +1,332 @@
+"""data-extractor health evaluator (P2.7, petrosa_k8s#697 AC2 / #259).
+
+Emits ``evaluator.data-extractor.verdict`` via the shared P2.1 framework
+(:mod:`petrosa_otel.evaluators`) so the operator dashboard's evaluator strip
+counts the data-extractor among the reporting subsystems (FR17 / FR23 / FR32).
+
+CronJob design (the explicit choice the ticket asks the implementer to justify):
+the data-extractor's real work runs in short-lived Kubernetes CronJob pods —
+those pods exit between runs, so an in-pod evaluator would lose its hysteresis
+state every run and emit a single sample at a cadence governed by the cron
+schedule (sparse and bursty). Instead we host the evaluator in the **long-lived
+API pod** (`api/main.py` FastAPI lifespan) and let it **subscribe to the
+existing ``binance.extraction.>`` NATS completion stream** that every cron run
+already publishes via `utils/messaging.publish_extraction_completion_*`. That
+gives the evaluator (a) a long-lived process for hysteresis state and emit
+loop, and (b) cross-cron visibility for "completion rate" and "last successful
+extraction lag" signals — without adding any new always-on sidecar deployment.
+
+The three signals (per #697 AC2):
+
+1. **CronJob completion rate** — count of ``extraction_completed`` events
+   observed inside the rolling window. Zero events over a long window while
+   the API pod is healthy means cron pods stopped firing (or NATS connectivity
+   to the API pod is broken).
+2. **Last-successful-extraction lag** — wall-clock seconds since the most
+   recent message with ``success == true``. Beyond the silence threshold
+   (default 30 min) the verdict trips, even if failure events keep arriving.
+3. **Binance API 429 rate** — fraction of recent completion messages whose
+   ``errors`` list mentions a 429 / rate-limit signature. A sustained ratio
+   above the threshold trips the verdict (with a minimum-volume guard so a
+   single rate-limited cron doesn't flap it).
+
+Verdict vocabulary is the framework's locked three-state contract
+(``healthy`` / ``unhealthy`` / ``unknown``); any breached signal maps to
+``unhealthy`` with a single-line reason naming the tripped signal (NFR-O5).
+
+Hysteresis / cadence (AC4 / AC7, FR18 per-evaluator ``decision_window``):
+emits every ``EMIT_INTERVAL_S`` (15s) with ``ConsecutiveSamplesHysteresis(n=3)``
+→ ~45s decision window. The window is generous on the silence + 429 checks
+because cron cadence itself is on the order of minutes; transient gaps between
+runs must not flap the verdict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import deque
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py310 compatibility
+    from datetime import timezone
+
+    UTC = timezone.utc  # noqa: UP017
+
+import nats
+from petrosa_otel.evaluators import (
+    ConsecutiveSamplesHysteresis,
+    Evaluator,
+    NatsVerdictPublisher,
+)
+
+if TYPE_CHECKING:
+    from petrosa_otel.evaluators.base import HysteresisPolicy
+    from petrosa_otel.evaluators.publisher import VerdictPublisher
+
+logger = logging.getLogger(__name__)
+
+SUBSYSTEM = "data-extractor"
+
+# Cadence + smoothing (documented per AC4 / AC7).
+EMIT_INTERVAL_S = 15.0
+HYSTERESIS_SAMPLES = 3
+
+# Rolling window for the completion-rate + 429-rate accumulators.
+DEFAULT_WINDOW = timedelta(minutes=30)
+# No successful extraction in this many seconds → unhealthy. Default 30 min
+# accommodates the slowest cron cadence (1h klines would push this higher per
+# operator override).
+DEFAULT_SILENCE_THRESHOLD_S = 30 * 60
+# 429 / rate-limit ratio above this trips the verdict.
+DEFAULT_RATE_LIMIT_RATIO_THRESHOLD = 0.5
+# Minimum completion volume in the window before the 429-rate check may trip.
+DEFAULT_MIN_COMPLETIONS_FOR_RATE_CHECK = 4
+
+# NATS subject the data-extractor already publishes completion events on.
+COMPLETION_SUBJECT_DEFAULT = "binance.extraction.>"
+
+_RATE_LIMIT_NEEDLES = ("429", "rate limit", "rate_limit", "too many requests")
+
+
+def _message_has_rate_limit_error(payload: dict[str, Any]) -> bool:
+    """True when the completion message's ``errors`` list mentions a 429."""
+    errors = payload.get("errors") or []
+    if not isinstance(errors, list):
+        return False
+    for entry in errors:
+        text = str(entry).lower()
+        if any(needle in text for needle in _RATE_LIMIT_NEEDLES):
+            return True
+    return False
+
+
+class DataExtractorHealthEvaluator(Evaluator):
+    """Subsystem evaluator for the data-extractor's CronJob-driven pipeline."""
+
+    def __init__(
+        self,
+        *,
+        publisher: VerdictPublisher | None = None,
+        hysteresis: HysteresisPolicy | None = None,
+        window: timedelta = DEFAULT_WINDOW,
+        silence_threshold_s: float = DEFAULT_SILENCE_THRESHOLD_S,
+        rate_limit_ratio_threshold: float = DEFAULT_RATE_LIMIT_RATIO_THRESHOLD,
+        min_completions_for_rate_check: int = DEFAULT_MIN_COMPLETIONS_FOR_RATE_CHECK,
+        emit_interval_s: float = EMIT_INTERVAL_S,
+        time_source: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__(
+            subsystem=SUBSYSTEM,
+            publisher=publisher,
+            hysteresis=hysteresis or ConsecutiveSamplesHysteresis(n=HYSTERESIS_SAMPLES),
+        )
+        self._window = window
+        self._silence_threshold_s = silence_threshold_s
+        self._rate_limit_ratio_threshold = rate_limit_ratio_threshold
+        self._min_completions_for_rate_check = max(1, min_completions_for_rate_check)
+        self._emit_interval_s = emit_interval_s
+        self._time = time_source or (lambda: datetime.now(UTC))
+
+        # In-process completion log: (observed_at, success, has_429).
+        self._completions: deque[tuple[datetime, bool, bool]] = deque()
+        self._last_success_at: datetime | None = None
+
+        self._emit_task: asyncio.Task[Any] | None = None
+
+    # ----- ingestion -----
+
+    def record_completion(self, payload: dict[str, Any]) -> None:
+        """Record one parsed completion message into the rolling window."""
+        success = bool(payload.get("success"))
+        has_429 = _message_has_rate_limit_error(payload)
+        observed_at = self._time()
+        self._completions.append((observed_at, success, has_429))
+        if success:
+            self._last_success_at = observed_at
+
+    async def _on_nats_message(self, msg: Any) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+        except (json.JSONDecodeError, AttributeError, UnicodeDecodeError) as exc:
+            logger.warning(
+                "data_extractor_health_evaluator_unparseable_message",
+                extra={"error": str(exc)},
+            )
+            return
+        event_type = data.get("event_type")
+        if event_type in ("extraction_completed", "batch_extraction_completed"):
+            self.record_completion(data)
+
+    # ----- lifecycle (used when the evaluator owns its NATS subscription) -----
+
+    async def start_emit_loop(self) -> None:
+        """Start the periodic emit loop (idempotent)."""
+        if self._emit_task is not None:
+            return
+        self._emit_task = asyncio.create_task(self._emit_loop())
+
+    async def stop_emit_loop(self) -> None:
+        """Stop the periodic emit loop."""
+        if self._emit_task is None:
+            return
+        self._emit_task.cancel()
+        try:
+            await self._emit_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"data_extractor_health_evaluator stop error: {exc}")
+        self._emit_task = None
+
+    async def _emit_loop(self) -> None:
+        while True:
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 — never crash the loop
+                logger.warning(
+                    "data_extractor_health_evaluator_tick_failed",
+                    extra={"error": str(exc)},
+                )
+            await asyncio.sleep(self._emit_interval_s)
+
+    # ----- framework hook -----
+
+    async def evaluate(self) -> tuple[str, str]:
+        """Compute the raw ``(verdict, reason)`` sample from the rolling window."""
+        now = self._time()
+        cutoff = now - self._window
+        while self._completions and self._completions[0][0] < cutoff:
+            self._completions.popleft()
+
+        total = len(self._completions)
+        rate_limited = sum(1 for _, _, has429 in self._completions if has429)
+
+        # 1) Last-successful-extraction lag. Tripping this is independent of how
+        # many failures are arriving: a flood of 429-failures with zero successes
+        # is still unhealthy.
+        if self._last_success_at is None:
+            if total == 0:
+                return "unknown", "no extraction completions observed yet"
+            return (
+                "unhealthy",
+                f"no successful extraction observed ({total} failures in last "
+                f"{int(self._window.total_seconds())}s)",
+            )
+        lag_s = (now - self._last_success_at).total_seconds()
+        if lag_s > self._silence_threshold_s:
+            return (
+                "unhealthy",
+                f"last successful extraction {int(lag_s)}s ago > "
+                f"{int(self._silence_threshold_s)}s threshold",
+            )
+
+        # 2) Binance API 429 rate (only when we have enough samples).
+        if total >= self._min_completions_for_rate_check:
+            ratio = rate_limited / total
+            if ratio > self._rate_limit_ratio_threshold:
+                pct = int(round(ratio * 100))
+                return (
+                    "unhealthy",
+                    f"Binance 429 pressure: {rate_limited}/{total} "
+                    f"({pct}%) of completions rate-limited",
+                )
+
+        # 3) Healthy summary.
+        return (
+            "healthy",
+            f"{total} completions in last "
+            f"{int(self._window.total_seconds())}s, last-success {int(lag_s)}s ago, "
+            f"{rate_limited} rate-limited",
+        )
+
+
+def build_data_extractor_health_evaluator(
+    *,
+    nats_servers: str | None,
+) -> DataExtractorHealthEvaluator | None:
+    """Construct an evaluator subscribed to `binance.extraction.>` completions.
+
+    Returns ``None`` when ``nats_servers`` is empty (NATS disabled).
+
+    The returned object exposes ``start()`` and ``stop()`` async lifecycle
+    methods that own the NATS connection + subscription + emit loop. Wire those
+    into the FastAPI lifespan in :mod:`api.main`.
+    """
+    if not nats_servers:
+        logger.info(
+            "data_extractor_health_evaluator not started: NATS disabled (no servers)"
+        )
+        return None
+
+    evaluator = DataExtractorHealthEvaluator()
+
+    # Attach the connection-owning start/stop wrapper as bound methods. The
+    # wrapper holds the live NATS client; the underlying evaluator stays a
+    # plain Evaluator subclass (testable without any NATS in unit tests).
+    nc_holder: dict[str, Any] = {"client": None, "sub": None}
+
+    async def _start() -> None:
+        if nc_holder["client"] is not None:
+            return
+        try:
+            nc = await nats.connect(
+                servers=nats_servers,
+                name="petrosa-data-extractor-evaluator",
+                allow_reconnect=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade, never crash startup
+            logger.warning(
+                "data_extractor_health_evaluator NATS connect failed: %s — "
+                "evaluator will not publish",
+                exc,
+            )
+            return
+        nc_holder["client"] = nc
+        evaluator._publisher = NatsVerdictPublisher(nats_client=nc)
+        try:
+            nc_holder["sub"] = await nc.subscribe(
+                COMPLETION_SUBJECT_DEFAULT, cb=evaluator._on_nats_message
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "data_extractor_health_evaluator subscribe failed: %s — "
+                "evaluator will publish unknown verdicts",
+                exc,
+            )
+        await evaluator.start_emit_loop()
+        logger.info(
+            "data_extractor_health_evaluator_started",
+            extra={
+                "subsystem": SUBSYSTEM,
+                "subject": COMPLETION_SUBJECT_DEFAULT,
+                "emit_interval_s": evaluator._emit_interval_s,
+            },
+        )
+
+    async def _stop() -> None:
+        await evaluator.stop_emit_loop()
+        sub = nc_holder.get("sub")
+        if sub is not None:
+            try:
+                await sub.unsubscribe()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"data_extractor_health_evaluator unsubscribe: {exc}")
+            nc_holder["sub"] = None
+        nc = nc_holder.get("client")
+        if nc is not None:
+            try:
+                await nc.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"data_extractor_health_evaluator close: {exc}")
+            nc_holder["client"] = None
+            evaluator._publisher = None
+
+    evaluator.start = _start  # type: ignore[method-assign]
+    evaluator.stop = _stop  # type: ignore[method-assign]
+    return evaluator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",
     "prometheus-client>=0.19.0",
-    "petrosa-otel[mysql,mongodb]>=1.0.0",
+    "petrosa-otel[mysql,mongodb]>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ numpy<2.0
 # For local development, install from path:
 # pip install -e ../petrosa_k8s/petrosa-otel[all]
 # For production, this will be published to private PyPI
-petrosa-otel[all]>=1.0.4
+petrosa-otel[all]>=1.1.0
 # Explicit SQLAlchemy instrumentation (required by utils/telemetry.py and MySQL adapter)
 opentelemetry-instrumentation-sqlalchemy>=0.45b0
 

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -1,0 +1,224 @@
+"""Unit tests for DataExtractorHealthEvaluator (#259, P2.7 AC2)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from petrosa_otel.evaluators import ConsecutiveSamplesHysteresis
+from petrosa_otel.evaluators.publisher import (
+    EVALUATOR_SUBJECT_TEMPLATE,
+    NatsVerdictPublisher,
+)
+
+from evaluators import (
+    DataExtractorHealthEvaluator,
+    build_data_extractor_health_evaluator,
+)
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self._t = start
+
+    def __call__(self) -> datetime:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t = self._t + timedelta(seconds=seconds)
+
+
+class FakeNats:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, payload: bytes) -> None:
+        self.messages.append((subject, payload))
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock(datetime(2026, 5, 28, 0, 0, 0, tzinfo=UTC))
+
+
+def _make(
+    clock, *, publisher=None, n: int = 1, **kwargs
+) -> DataExtractorHealthEvaluator:
+    return DataExtractorHealthEvaluator(
+        publisher=publisher,
+        hysteresis=ConsecutiveSamplesHysteresis(n=n),
+        time_source=clock,
+        **kwargs,
+    )
+
+
+def _completion(*, success: bool = True, errors: list | None = None) -> dict:
+    return {
+        "event_type": "extraction_completed",
+        "extraction_type": "klines",
+        "symbol": "BTCUSDT",
+        "period": "15m",
+        "success": success,
+        "errors": errors or [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_completions_observed_is_unknown(clock):
+    ev = _make(clock)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unknown"
+    assert "no extraction completions" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_recent_successful_completions(clock):
+    ev = _make(clock)
+    for _ in range(5):
+        ev.record_completion(_completion(success=True))
+        clock.advance(30)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "5 completions" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_all_completions_failed(clock):
+    ev = _make(clock)
+    for _ in range(3):
+        ev.record_completion(_completion(success=False, errors=["http 500"]))
+        clock.advance(60)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "no successful extraction" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_when_last_success_exceeds_silence_threshold(clock):
+    ev = _make(clock, silence_threshold_s=300)
+    ev.record_completion(_completion(success=True))
+    clock.advance(400)  # > 5 min silence threshold
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "last successful extraction" in reason
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_on_429_pressure_above_threshold(clock):
+    ev = _make(
+        clock,
+        rate_limit_ratio_threshold=0.5,
+        min_completions_for_rate_check=4,
+    )
+    # Establish a recent success first so the silence check stays healthy.
+    ev.record_completion(_completion(success=True))
+    clock.advance(10)
+    # Then five rate-limited failures.
+    for _ in range(5):
+        ev.record_completion(
+            _completion(success=False, errors=["binance: 429 too many requests"])
+        )
+        clock.advance(10)
+    verdict, reason = await ev.evaluate()
+    assert verdict == "unhealthy"
+    assert "429 pressure" in reason
+
+
+@pytest.mark.asyncio
+async def test_low_volume_429_does_not_trip_rate_check(clock):
+    ev = _make(
+        clock,
+        rate_limit_ratio_threshold=0.5,
+        min_completions_for_rate_check=4,
+    )
+    ev.record_completion(_completion(success=True))
+    clock.advance(10)
+    # Two rate-limited failures — below the min-volume guard (4).
+    ev.record_completion(_completion(success=False, errors=["429"]))
+    ev.record_completion(_completion(success=False, errors=["429"]))
+    verdict, _ = await ev.evaluate()
+    assert verdict == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_window_prunes_old_completions(clock):
+    ev = _make(clock, window=timedelta(seconds=60))
+    ev.record_completion(_completion(success=True))
+    clock.advance(120)  # past the 60s window
+    # Inside-window event keeps the window non-empty.
+    ev.record_completion(_completion(success=True))
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    # Only the recent completion should be counted.
+    assert "1 completions" in reason
+
+
+@pytest.mark.asyncio
+async def test_on_nats_message_records_completion(clock):
+    ev = _make(clock)
+
+    class _Msg:
+        def __init__(self, payload: dict) -> None:
+            self.data = json.dumps(payload).encode()
+
+    await ev._on_nats_message(_Msg(_completion(success=True)))
+    await ev._on_nats_message(
+        _Msg({"event_type": "something_else", "success": True})
+    )  # ignored
+
+    verdict, reason = await ev.evaluate()
+    assert verdict == "healthy"
+    assert "1 completions" in reason
+
+
+@pytest.mark.asyncio
+async def test_on_nats_message_ignores_malformed(clock):
+    ev = _make(clock)
+
+    class _BadMsg:
+        data = b"not-json"
+
+    await ev._on_nats_message(_BadMsg())  # must not raise
+    verdict, _ = await ev.evaluate()
+    assert verdict == "unknown"  # no completions recorded
+
+
+@pytest.mark.asyncio
+async def test_publishes_on_data_extractor_subject(clock):
+    nats = FakeNats()
+    ev = _make(clock, publisher=NatsVerdictPublisher(nats_client=nats), n=1)
+
+    # First tick: no completions yet → unknown.
+    await ev.tick()
+    # Second tick: one successful completion → healthy.
+    ev.record_completion(_completion(success=True))
+    await ev.tick()
+
+    assert nats.messages, "evaluator did not publish"
+    subject, payload = nats.messages[-1]
+    assert subject == "evaluator.data-extractor.verdict"
+    assert subject == EVALUATOR_SUBJECT_TEMPLATE.format(subsystem="data-extractor")
+    body = json.loads(payload.decode())
+    assert body["subsystem"] == "data-extractor"
+    assert body["verdict"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_hysteresis_suppresses_single_flap(clock):
+    ev = _make(clock, n=3, silence_threshold_s=120)
+    # Commit healthy with 3 consecutive samples.
+    for _ in range(3):
+        ev.record_completion(_completion(success=True))
+        v = await ev.tick()
+    assert v.verdict == "healthy"
+
+    # One silent tick (advance past silence threshold) — n=3 must keep healthy.
+    clock.advance(200)
+    v = await ev.tick()
+    assert v.verdict == "healthy"
+
+
+def test_build_returns_none_when_nats_disabled():
+    assert build_data_extractor_health_evaluator(nats_servers=None) is None
+    assert build_data_extractor_health_evaluator(nats_servers="") is None

--- a/tests/unit/test_health_evaluator.py
+++ b/tests/unit/test_health_evaluator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from petrosa_otel.evaluators import ConsecutiveSamplesHysteresis
@@ -222,3 +223,107 @@ async def test_hysteresis_suppresses_single_flap(clock):
 def test_build_returns_none_when_nats_disabled():
     assert build_data_extractor_health_evaluator(nats_servers=None) is None
     assert build_data_extractor_health_evaluator(nats_servers="") is None
+
+
+@pytest.mark.asyncio
+async def test_start_stop_emit_loop_publishes(clock):
+    """The emit loop runs, publishes at least once, and stop() cancels it."""
+    nats = FakeNats()
+    ev = _make(
+        clock,
+        publisher=NatsVerdictPublisher(nats_client=nats),
+        n=1,
+    )
+    # Tighter cadence so the test runs quickly.
+    ev._emit_interval_s = 0.01
+    await ev.start_emit_loop()
+    await ev.start_emit_loop()  # idempotent
+
+    import asyncio
+
+    await asyncio.sleep(0.05)
+    await ev.stop_emit_loop()
+    await ev.stop_emit_loop()  # idempotent
+
+    assert nats.messages, "emit loop did not publish"
+    subject, _ = nats.messages[-1]
+    assert subject == "evaluator.data-extractor.verdict"
+
+
+@pytest.mark.asyncio
+async def test_build_factory_handles_nats_connect_failure(monkeypatch):
+    """A failing `nats.connect` must degrade the evaluator gracefully."""
+    import evaluators.health_evaluator as he
+
+    class _FailingNats:
+        async def connect(self, *args, **kwargs):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(he, "nats", _FailingNats())
+
+    ev = build_data_extractor_health_evaluator(nats_servers="nats://nowhere:4222")
+    assert ev is not None
+    # start() must NOT raise even though connect failed.
+    await ev.start()
+    # The publisher should remain unset and no emit task should be running
+    # since the wrapper only starts the loop on successful connect — but if
+    # the wrapper started a loop, stop() still cleans up.
+    await ev.stop()
+
+
+@pytest.mark.asyncio
+async def test_build_factory_subscribes_and_publishes_through_owned_client(monkeypatch):
+    """The full happy path: build → start → ingest → stop, all via the factory."""
+    import evaluators.health_evaluator as he
+
+    published: list[tuple[str, bytes]] = []
+    captured: dict[str, Any] = {}
+
+    class _FakeSub:
+        async def unsubscribe(self):
+            captured["unsubscribed"] = True
+
+    class _FakeClient:
+        is_connected = True
+
+        async def publish(self, subject: str, payload: bytes) -> None:
+            published.append((subject, payload))
+
+        async def subscribe(self, subject: str, cb):
+            captured["subject"] = subject
+            captured["cb"] = cb
+            return _FakeSub()
+
+        async def close(self) -> None:
+            captured["closed"] = True
+
+    class _FakeNatsModule:
+        async def connect(self, *args, **kwargs):
+            return _FakeClient()
+
+    monkeypatch.setattr(he, "nats", _FakeNatsModule())
+
+    ev = build_data_extractor_health_evaluator(nats_servers="nats://stub:4222")
+    assert ev is not None
+    ev._emit_interval_s = 0.01
+
+    await ev.start()
+    # Subscription was registered on the right subject and a publisher attached.
+    assert captured["subject"] == he.COMPLETION_SUBJECT_DEFAULT
+    assert ev._publisher is not None
+
+    # Deliver one completion message through the actual subscription callback.
+    class _Msg:
+        data = json.dumps(_completion(success=True)).encode()
+
+    await captured["cb"](_Msg())
+
+    import asyncio
+
+    await asyncio.sleep(0.05)
+    await ev.stop()
+
+    assert published, "evaluator did not publish through the owned NATS client"
+    assert published[-1][0] == "evaluator.data-extractor.verdict"
+    assert captured.get("unsubscribed") is True
+    assert captured.get("closed") is True


### PR DESCRIPTION
## Summary

Adopts the shared **P2.1 evaluator framework** (`petrosa_otel.evaluators`) so `petrosa-binance-data-extractor` publishes a structured health verdict on **`evaluator.data-extractor.verdict`** — closing the **last** of the five "silent service" gaps that keep **FR17 / FR23 / FR32** at 🟡 YELLOW (parent EPIC [petrosa_k8s#697](https://github.com/PetroSa2/petrosa_k8s/issues/697), AC2).

Implements [#259](https://github.com/PetroSa2/petrosa-binance-data-extractor/issues/259). Completes the P2.7 sweep alongside socket-client #123, realtime-strategies #175, bot-ta-analysis #248, and tradeengine #417 (all merged today).

## CronJob design decision (the ticket asks the implementer to justify)

The data-extractor's real work runs in short-lived **Kubernetes CronJob** pods — those pods exit between runs, so an in-pod evaluator would lose its hysteresis state every run and emit at the cron cadence (sparse and bursty, with no smoothing).

This PR takes the **second option from the ticket: a long-lived host**, but reuses the *already-deployed* API pod (`api/main.py` FastAPI lifespan) instead of adding a new sidecar. The evaluator **subscribes to the existing `binance.extraction.>` NATS completion stream** that every cron run already publishes via `utils/messaging.publish_extraction_completion_sync`. That gives:

1. A long-lived process with stable hysteresis state and a steady emit loop.
2. Cross-cron visibility for "completion rate" and "last-successful-extraction lag" without any new infra (no sidecar Deployment, no new image).
3. No changes to any of the cron entrypoints in `jobs/` — they keep publishing the same completion events they've always published.

## What changed

- **`DataExtractorHealthEvaluator`** (`evaluators/health_evaluator.py`) subclasses `petrosa_otel.evaluators.Evaluator` and combines three signals (per #697 AC2):
  - **CronJob completion rate** — count of `extraction_completed` events in the rolling window. Zero events while the API pod is healthy means cron pods stopped firing (or NATS connectivity to the API pod broke).
  - **Last-successful-extraction lag** — wall-clock seconds since the most recent message with `success == true`. Beyond the silence threshold (default 30 min) the verdict trips, even if failure events keep arriving.
  - **Binance API 429 rate** — fraction of recent completions whose `errors` list mentions a 429 / rate-limit signature. Guarded by a minimum-volume threshold so a single rate-limited cron doesn't flap it.
- Publishes via the framework `NatsVerdictPublisher` on `evaluator.data-extractor.verdict`.
- **Hysteresis (AC4 / AC7):** `ConsecutiveSamplesHysteresis(n=3)` over 15s → ~45s decision window (documented in the module docstring; the window is generous because cron cadence itself is on the order of minutes).
- **Lifecycle:** wired into `api/main.py` lifespan — start before the yield, stop after. The factory owns a dedicated NATS connection (lazy: connect + subscribe in `start()`, unsubscribe + close in `stop()`). Guarded so an older `petrosa-otel` degrades gracefully (ImportError → evaluator disabled).
- **Dependency:** `petrosa-otel` pin `>=1.0.4` → `>=1.1.0` (first published version shipping the evaluators framework).

### Verdict vocabulary note
The framework's `EvaluatorVerdict` enforces the locked three-state contract `healthy | unhealthy | unknown` (no `degraded`). Any breached signal maps to **`unhealthy`** with a single-line reason naming the tripped signal (NFR-O5). Consistent with all shipped producers.

## Acceptance criteria

- [x] **AC1** — `DataExtractorHealthEvaluator(petrosa_otel.evaluators.Evaluator)` exists and is wired into the service's run path (per the CronJob-vs-loop decision documented above).
- [x] **AC2** — Publishes `evaluator.data-extractor.verdict` (framework publisher) with verdict + reason.
- [x] **AC3** — The three health signals feed the raw verdict.
- [x] **AC4** — Hysteresis applied; threshold/window documented (the choice is matched to the cron cadence rather than per-tick CPU signals).
- [x] **AC5** — Unit tests cover verdict transitions + publish subject.
- [x] **AC6** — CI (ruff / mypy / tests) — validated locally; see test plan.

## Test plan

- [x] `pytest tests/unit/test_health_evaluator.py` — 12 tests: unknown when no completions, healthy with recent successes, unhealthy when all completions failed, unhealthy on silence-threshold timeout, unhealthy on 429 pressure, dormant on low-volume 429s, window pruning, NATS-message ingestion + malformed-message tolerance, publish-subject assertion (`evaluator.data-extractor.verdict`), hysteresis flap suppression, build returning `None` when NATS disabled.
- [x] `ruff check` clean; `ruff format` clean.
- Pre-existing local-env caveat: a handful of `tests/test_extract_klines_data_manager.py` tests time out locally because they trigger a real `nats.connect` against `localhost:4222` from the existing `publish_extraction_completion_sync` path; this is unrelated to this PR (those code paths are untouched here) and CI's NATS handling will give the authoritative signal.

Closes #259
