### PR TITLE
feat(metrics): emit extractor.binance.weight.used_1m OTel metric (#696)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -75,6 +75,15 @@ API_RATE_LIMIT = int(os.getenv("API_RATE_LIMIT", "1200"))  # requests per minute
 API_RATE_LIMIT_PER_MINUTE = int(
     os.getenv("API_RATE_LIMIT_PER_MINUTE", "1200")
 )  # requests per minute
+
+# Binance weight-budget ceiling (#696 / NFR-I5): operational target vs hard limit
+BINANCE_WEIGHT_HARD_LIMIT = int(
+    os.getenv("BINANCE_WEIGHT_HARD_LIMIT", "1200")
+)  # wu/min
+BINANCE_WEIGHT_CEILING_PCT = float(
+    os.getenv("BINANCE_WEIGHT_CEILING_PCT", "0.60")
+)  # 60% target
+
 API_TIMEOUT = int(os.getenv("API_TIMEOUT", "30"))
 REQUEST_DELAY_SECONDS = float(os.getenv("REQUEST_DELAY_SECONDS", "0.1"))
 

--- a/fetchers/client.py
+++ b/fetchers/client.py
@@ -171,6 +171,14 @@ class BinanceClient:
             latency_ms = duration * 1000
             self.metrics.record_api_latency(endpoint, latency_ms, response.status_code)
 
+            # Emit weight-budget metric from Binance rolling 1-minute header
+            weight_header = response.headers.get("X-MBX-USED-WEIGHT-1M")
+            if weight_header is not None:
+                try:
+                    self.metrics.record_binance_weight(int(weight_header))
+                except (ValueError, TypeError):
+                    pass
+
             # Handle different response codes
             if response.status_code == 200:
                 return response.json()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -78,8 +78,8 @@ class TestExtractionMetrics:
             mock_meter.create_counter.call_count == 4
         )  # extraction, gaps, records_written, records_fetched
         assert (
-            mock_meter.create_histogram.call_count == 4
-        )  # api_latency, rate_limit_used, rate_limit_remaining, throughput
+            mock_meter.create_histogram.call_count == 5
+        )  # api_latency, rate_limit_used, rate_limit_remaining, throughput, binance_weight_1m
         assert (
             mock_meter.create_up_down_counter.call_count == 0
         )  # No up-down counters used

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -92,6 +92,13 @@ class ExtractionMetrics:
             unit="1",
         )
 
+        # Binance rolling 1-minute weight consumed (X-MBX-USED-WEIGHT-1M response header)
+        self.binance_weight_1m = self.meter.create_histogram(
+            name="extractor.binance.weight.used_1m",
+            description="Binance API weight consumed in the rolling 1-minute window",
+            unit="1",
+        )
+
         logger.info("Extraction metrics initialized successfully")
 
     def record_extraction(
@@ -192,6 +199,21 @@ class ExtractionMetrics:
             self.rate_limit_remaining.record(remaining, {"limit": str(limit)})
         except Exception as e:
             logger.warning(f"Failed to record rate limit metrics: {e}")
+
+    def record_binance_weight(self, weight_used: int) -> None:
+        """
+        Record Binance rolling 1-minute weight from the X-MBX-USED-WEIGHT-1M header.
+
+        Args:
+            weight_used: Weight consumed in the current 1-minute window
+        """
+        if not self._metrics_enabled:
+            return
+
+        try:
+            self.binance_weight_1m.record(weight_used, {"exchange": "binance"})
+        except Exception as e:
+            logger.warning(f"Failed to record Binance weight metric: {e}")
 
 
 # Global metrics instance


### PR DESCRIPTION
## Summary
Re-ships **petrosa_k8s#696** AC1+AC2. The metric was marked done via PR #257 (`d6631ce`) — ACs checked, merged green — but the squashed commit contained **none of the implementation**. `utils/metrics.py` and `fetchers/client.py` on `main` have zero weight-metric code, so `extractor.binance.weight.used_1m` has been dark in production since 2026-05-27. This restores the implementation (recovered from a working tree during a repo-hygiene sweep).

## Changes
- `utils/metrics.py`: `binance_weight_1m` histogram (`extractor.binance.weight.used_1m`) + `record_binance_weight()`
- `fetchers/client.py`: read `X-MBX-USED-WEIGHT-1M` header per `BinanceClient.get()` and emit the metric
- `constants.py`: `BINANCE_WEIGHT_HARD_LIMIT` (1200) + `BINANCE_WEIGHT_CEILING_PCT` (0.60) — AC2 / NFR-I5
- `tests/test_metrics.py`: assert 5 histogram instruments

## Acceptance Criteria
- [x] AC1: `extractor.binance.weight.used_1m` emitted on every API response via `X-MBX-USED-WEIGHT-1M`
- [x] AC2: configurable ceiling constants

## Tests
717 passed, 2 skipped (full suite).

## Note
PR #257 is a confirmed ghost-merge (green + ACs checked, empty diff). Flagging the merge-gate gap separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)