### PR TITLE
fix(#267-AC1): remove dead extraction_metadata write path

### DIFF
--- a/db/base_adapter.py
+++ b/db/base_adapter.py
@@ -189,15 +189,6 @@ class BaseAdapter(ABC):
             Number of records deleted
         """
 
-    def write_extraction_metadata(self, metadata: ExtractionMetadata) -> None:
-        """
-        Write extraction metadata to track extraction runs.
-
-        Args:
-            metadata: ExtractionMetadata instance
-        """
-        self.write([metadata], "extraction_metadata")
-
     def is_connected(self) -> bool:
         """Check if adapter is connected to database."""
         return self._connected

--- a/db/mysql_adapter.py
+++ b/db/mysql_adapter.py
@@ -173,24 +173,6 @@ class MySQLAdapter(BaseAdapter):
             Index("idx_funding_rates_funding_time", "funding_time"),
         )
 
-        # Extraction metadata table
-        self.tables["extraction_metadata"] = Table(
-            "extraction_metadata",
-            self.metadata,
-            Column("extraction_id", String(64), primary_key=True),
-            Column("period", String(10), nullable=False),
-            Column("start_time", DateTime, nullable=False),
-            Column("end_time", DateTime, nullable=False),
-            Column("total_records", Integer, nullable=False, default=0),
-            Column("gaps_detected", Integer, nullable=False, default=0),
-            Column("backfill_performed", Boolean, nullable=False, default=False),
-            Column(
-                "extraction_duration_seconds", Numeric(10, 3), nullable=False, default=0
-            ),
-            Column("extracted_at", DateTime, nullable=False),
-            Index("idx_extraction_metadata_period_start", "period", "start_time"),
-        )
-
         # Create all tables
         if self.engine is not None:
             self.metadata.create_all(self.engine)

--- a/tests/unit/test_database_adapters.py
+++ b/tests/unit/test_database_adapters.py
@@ -13,7 +13,7 @@ import pytest
 from db.base_adapter import BaseAdapter, DatabaseError
 from db.mongodb_adapter import MongoDBAdapter
 from db.mysql_adapter import MySQLAdapter
-from models.base import BaseTimestampedModel, ExtractionMetadata
+from models.base import BaseTimestampedModel
 
 
 class SampleTestModel(BaseTimestampedModel):
@@ -155,58 +155,6 @@ class TestBaseAdapter:
         assert adapter.is_connected() is True
         adapter.disconnect()
         assert adapter.is_connected() is False
-
-    def test_write_extraction_metadata(self):
-        """Test write_extraction_metadata method."""
-
-        class ConcreteAdapter(BaseAdapter):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.written_data = []
-
-            def connect(self):
-                pass
-
-            def disconnect(self):
-                pass
-
-            def write(self, model_instances, collection):
-                self.written_data.append((model_instances, collection))
-                return len(model_instances)
-
-            def write_batch(self, model_instances, collection, batch_size=1000):
-                return 0
-
-            def query_range(self, collection, start, end, symbol=None):
-                return []
-
-            def query_latest(self, collection, symbol=None, limit=1):
-                return []
-
-            def find_gaps(self, collection, start, end, interval_minutes, symbol=None):
-                return []
-
-            def get_record_count(self, collection, start=None, end=None, symbol=None):
-                return 0
-
-            def ensure_indexes(self, collection):
-                pass
-
-            def delete_range(self, collection, start, end, symbol=None):
-                return 0
-
-        adapter = ConcreteAdapter("test_connection")
-        metadata = ExtractionMetadata(
-            period="15m",
-            start_time=datetime.now(),
-            end_time=datetime.now() + timedelta(hours=1),
-        )
-
-        adapter.write_extraction_metadata(metadata)
-
-        assert len(adapter.written_data) == 1
-        assert adapter.written_data[0][1] == "extraction_metadata"
-        assert adapter.written_data[0][0][0] == metadata
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

AC1 of #267: `extraction_metadata` table had 0 rows because `write_extraction_metadata()` was defined in `base_adapter.py` but never called from any extraction job (`extract_klines`, `extract_funding`, `extract_trades`).

## Decision: REMOVE

Root cause: the method existed as a stub that was never wired up to any job. Since no code calls it and no data was ever collected, the correct fix is to remove the dead code path rather than silently wire it up to a job.

## Changes

- Remove `write_extraction_metadata()` from `db/base_adapter.py`
- Remove `extraction_metadata` table definition from `db/mysql_adapter.py`
- Remove `test_write_extraction_metadata` test and unused `ExtractionMetadata` import from `tests/unit/test_database_adapters.py`

Refs: #267