### PR TITLE
fix(extractors): use `log=` kwarg for log_extraction_start (#269)

### DIFF
--- a/jobs/extract_funding.py
+++ b/jobs/extract_funding.py
@@ -98,7 +98,7 @@ def main():
     else:
         symbols = constants.DEFAULT_SYMBOLS
     log_extraction_start(
-        logger=logger,
+        log=logger,
         extractor_type="funding_rates",
         symbols=symbols,
         period="funding_rates",

--- a/jobs/extract_trades.py
+++ b/jobs/extract_trades.py
@@ -98,7 +98,7 @@ def main():
 
     # Log extraction start
     log_extraction_start(
-        logger=logger,
+        log=logger,
         extractor_type="trades",
         symbols=symbols,
         period="trades",

--- a/tests/test_extract_trades.py
+++ b/tests/test_extract_trades.py
@@ -287,3 +287,47 @@ class TestMain:
         with patch("sys.exit") as mock_exit:
             extract_trades.main()
             mock_exit.assert_called()
+
+
+class TestLogExtractionStartCallSites:
+    """Regression: AC4 — every job's `log_extraction_start(...)` call must use
+    the kwarg name from the function signature (`log=`), not the historical
+    `logger=`. The bug in #269 slipped past CI because `test_main_*` patched
+    `log_extraction_start` away, so the call-site mismatch never raised.
+
+    This test parses each `jobs/extract_*.py` AST and asserts no caller passes
+    a `logger=` keyword to `log_extraction_start`.
+    """
+
+    def test_no_caller_uses_logger_kwarg(self):
+        import ast
+        import glob
+        import inspect
+
+        from utils.logger import log_extraction_start
+
+        # Sanity: the canonical kwarg in the signature is `log`.
+        sig = inspect.signature(log_extraction_start)
+        assert "log" in sig.parameters
+        assert "logger" not in sig.parameters
+
+        jobs_dir = os.path.join(project_root, "jobs")
+        offenders = []
+        for path in sorted(glob.glob(os.path.join(jobs_dir, "extract_*.py"))):
+            with open(path, encoding="utf-8") as fh:
+                tree = ast.parse(fh.read(), filename=path)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = getattr(func, "id", None) or getattr(func, "attr", None)
+                if name != "log_extraction_start":
+                    continue
+                for kw in node.keywords:
+                    if kw.arg == "logger":
+                        offenders.append(f"{path}:{node.lineno}")
+
+        assert not offenders, (
+            "log_extraction_start() must be called with `log=`, not `logger=`. "
+            f"Offenders: {offenders}"
+        )


### PR DESCRIPTION
## Summary

Fixes the P0 in #269 — `binance-trades-production` CronJob has been crashing on every run with `TypeError: log_extraction_start() got an unexpected keyword argument 'logger'` since the v1.1.33-r179 image rolled out. Trades pipeline produces zero new rows until this lands.

## Root cause

Commit `0518f16` renamed the canonical kwarg `logger` → `log` in `utils/logger.py::log_extraction_start`. Two call sites were missed:

| File | Line | Status before |
|------|------|---------------|
| `jobs/extract_trades.py` | 100 | **Crashing every run** (production CronJob) |
| `jobs/extract_funding.py` | 101 | Latent — next funding CronJob run would have hit the same TypeError |

`extract_funding.py` was caught via the AC4 grep sweep (`grep -rn "log_extraction_start(\s*logger="`); ticket only flagged `extract_trades.py`, but the same surgical fix obviously belongs to both.

All other `jobs/extract_*.py` callers already use the correct `log=` kwarg.

## Why CI didn't catch this

`tests/test_extract_trades.py::TestMain` patches `log_extraction_start` away in every test, so the call-site kwarg mismatch never raised. This PR adds `TestLogExtractionStartCallSites::test_no_caller_uses_logger_kwarg` which AST-parses every `jobs/extract_*.py` and asserts no caller still passes `logger=`. It would have failed loudly on this regression and on any future drift.

## Acceptance criteria

- [x] **AC1** — `jobs/extract_trades.py:100` uses `log=logger`.
- [x] **AC2** — `pytest tests/test_extract_trades.py tests/test_logger.py` passes (32/32). New AST-based regression test included.
- [ ] **AC3** — Observe one successful `binance-trades-production-*` pod (status Completed, no TypeError). *Post-deploy verification — operator step after image rebuild.*
- [x] **AC4** — `grep -rn "log_extraction_start(\s*logger="` returns no hits. Surfaced `extract_funding.py` straggler and fixed it in the same commit.

## Test plan

```
$ uv run pytest tests/test_extract_trades.py tests/test_logger.py -q
32 passed, 18 warnings in 0.08s
```

Pre-commit (ruff, gitleaks, bandit, assertions check): all passed.

## Risk

Minimal — two-character kwarg rename at call sites. No behavior change beyond "stops crashing".

Closes #269
