### PR TITLE
fix: add ensure_indexes + write_batch to DataManagerAdapter (k8s#861 follow-up)

### DIFF
--- a/adapters/data_manager_adapter.py
+++ b/adapters/data_manager_adapter.py
@@ -315,6 +315,33 @@ class DataManagerAdapter:
 
         return await self._client.health_check()
 
+    def ensure_indexes(self, collection: str) -> None:
+        """No-op: data-manager handles its own indexing server-side."""
+
+    def write_batch(
+        self,
+        model_instances: list,
+        collection: str,
+        batch_size: int = 1000,
+    ) -> int:
+        """Synchronous write_batch: delegates to async write in batches."""
+        total_written = 0
+        for i in range(0, len(model_instances), batch_size):
+            batch = model_instances[i : i + batch_size]
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    import concurrent.futures
+
+                    with concurrent.futures.ThreadPoolExecutor() as pool:
+                        future = pool.submit(asyncio.run, self.write(batch, collection))
+                        total_written += future.result()
+                else:
+                    total_written += asyncio.run(self.write(batch, collection))
+            except RuntimeError:
+                total_written += asyncio.run(self.write(batch, collection))
+        return total_written
+
     def __enter__(self):
         """Synchronous context manager entry."""
         # Start event loop if not already running


### PR DESCRIPTION
## Summary

Follow-up to PetroSa2/petrosa_k8s#861 / PR #271.

After the `DATA_MANAGER_URL` fix landed, the CronJob's next run (21:25 UTC) crashed with a new error:
```
Extraction failed: 'DataManagerAdapter' object has no attribute 'ensure_indexes'
```

`DataManagerAdapter` extends `BaseAdapter` but was missing two required abstract methods that `extract_trades.py` (and other jobs) call unconditionally after getting an adapter.

## Changes

**`adapters/data_manager_adapter.py`**
- `ensure_indexes(collection)`: no-op — the data-manager service handles its own indexing server-side
- `write_batch(model_instances, collection, batch_size)`: delegates to the existing `async write()` in batches via `asyncio.run`

## Testing

44 tests pass (test_extract_trades.py + test_data_manager_adapter.py)

## AC Completion

- [x] AC1: `DATA_MANAGER_URL` correctly resolved (PR #271)
- [ ] AC2: CronJob completes at least one successful run — unblocked by this PR
- [ ] AC3: `container_terminated_error` clears in ops-health dry-run — post-deploy